### PR TITLE
Updates for subclassing, new fields from clinicaltrials.gov

### DIFF
--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -124,13 +124,13 @@ class Grounder:
         self, entity: BioEntity, context: Optional[str] = None
     ) -> Iterator[BioEntity]:
         return self.ground(entity, context)
-    
+
     def _create_grounded_entity(
-        self, entity: BioEntity, *, mesh_id: str, norm_text: str
+        self, entity: BioEntity, *, db_ns, db_id: str, norm_text: str
     ) -> BioEntity:
         grounded_entity = copy.deepcopy(entity)
-        grounded_entity.ns = 'MESH'
-        grounded_entity.ns_id = mesh_id
+        grounded_entity.ns = db_ns
+        grounded_entity.ns_id = db_id
         grounded_entity.grounded_term = norm_text
         return grounded_entity
 

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -205,7 +205,8 @@ class ConditionGrounder(Grounder):
     def __init__(
         self,
         namespaces: Optional[list[str]] = None,
-        annotator: Callable[[str], list[Tuple[Annotation]]] = None
+        annotator: Optional[AnnotatorSignature] = None,
+        grounder_func: Optional[GrounderSignature] = None,
     ):
         if namespaces is None:
             namespaces = CONDITION_NS
@@ -214,7 +215,8 @@ class ConditionGrounder(Grounder):
         super().__init__(
             namespaces=namespaces,
             restrict_mesh_prefix=['C', 'F'],
-            annotator=annotator
+            annotator=annotator,
+            grounder_func=grounder_func,
         )
 
 
@@ -222,7 +224,8 @@ class InterventionGrounder(Grounder):
     def __init__(
         self,
         namespaces: Optional[list[str]] = None,
-        annotator: Callable[[str], list[Tuple[Annotation]]] = None
+        annotator: Optional[AnnotatorSignature] = None,
+        grounder_func: Optional[GrounderSignature] = None,
     ):
         if namespaces is None:
             namespaces = INTERVENTION_NS
@@ -231,5 +234,6 @@ class InterventionGrounder(Grounder):
         super().__init__(
             namespaces=namespaces,
             restrict_mesh_prefix=['D', 'E'],
-            annotator=annotator
+            annotator=annotator,
+            grounder_func=grounder_func,
         )

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -31,9 +31,17 @@ class Annotator:
     def __init__(
         self,
         *,
-        namespaces: Optional[list[str]] = ["MESH"],
+        namespaces: Optional[list[str]] = None,
     ):
+        """Base class for annotators that annotate text with named entities.
 
+        Parameters
+        ----------
+        namespaces : Optional[list[str]]
+            A list of namespaces to consider for annotation. If None, defaults to ["MESH"].
+        """
+        if namespaces is None:
+            namespaces = ["MESH"]
         self.namespaces = namespaces
 
     def __call__(self, text: str, *, context: str = None) -> list[Annotation]:

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -145,17 +145,26 @@ class Grounder:
         self, entity: BioEntity, match: ScoredMatch
     ) -> Iterator[BioEntity]:
         groundings_dict = dict(match.get_groundings())
+        # Todo: check if this disrupts other groundings from e.g. vo
         mesh_id = groundings_dict.get('MESH')
-        
+
         if mesh_id:
             if self.restrict_mesh_prefix and any(mesh_client.has_tree_prefix(mesh_id, prefix) for prefix in self.restrict_mesh_prefix):
                 yield self._create_grounded_entity(
-                    entity, mesh_id=mesh_id, norm_text=match.term.entry_name
+                    entity, db_ns="MESH", db_id=mesh_id, norm_text=match.term.entry_name
                 )
             if not self.restrict_mesh_prefix:
                 yield self._create_grounded_entity(
-                    entity, mesh_id=mesh_id, norm_text=match.term.entry_name
+                    entity, db_ns="MESH", db_id=mesh_id, norm_text=match.term.entry_name
                 )
+        else:
+            # If no MESH ID is found, we yield the original entity with the match
+            yield self._create_grounded_entity(
+                entity,
+                db_ns=match.term.db,
+                db_id=match.term.id,
+                norm_text=match.term.entry_name,
+            )
 
     def ground(
         self, entity: BioEntity, context: Optional[str] = None

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -174,14 +174,37 @@ class Grounder:
                 annotations = self.annotator(entity.text)
                 for annotation in annotations:
                     yield from self._yield_entity(entity, annotation.matches[0])
-                    
 
 
 class ConditionGrounder(Grounder):
-    def __init__(self):
-        super().__init__(namespaces=CONDITION_NS, restrict_mesh_prefix=['C', 'F'], annotator=GildaAnnotator())
+    def __init__(
+        self,
+        namespaces: Optional[list[str]] = None,
+        annotator: Callable[[str], list[Tuple[Annotation]]] = None
+    ):
+        if namespaces is None:
+            namespaces = CONDITION_NS
+        if annotator is None:
+            annotator = GildaAnnotator(namespaces=namespaces)
+        super().__init__(
+            namespaces=namespaces,
+            restrict_mesh_prefix=['C', 'F'],
+            annotator=annotator
+        )
 
 
 class InterventionGrounder(Grounder):
-    def __init__(self):
-        super().__init__(namespaces=INTERVENTION_NS, restrict_mesh_prefix=['D', 'E'], annotator=GildaAnnotator())
+    def __init__(
+        self,
+        namespaces: Optional[list[str]] = None,
+        annotator: Callable[[str], list[Tuple[Annotation]]] = None
+    ):
+        if namespaces is None:
+            namespaces = INTERVENTION_NS
+        if annotator is None:
+            annotator = GildaAnnotator(namespaces=namespaces)
+        super().__init__(
+            namespaces=namespaces,
+            restrict_mesh_prefix=['D', 'E'],
+            annotator=annotator
+        )

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -58,9 +58,11 @@ class Annotator:
     def annotate(self, text: str, *, context: str = None) -> list[Annotation]:
         pass
 
+
 class GildaAnnotator(Annotator):
     def annotate(self, text: str, *, context: str = None):
         return gilda.annotate(text=text, context_text=context, namespaces=self.namespaces)
+
 
 class SciSpacyAnnotator(Annotator):
     def __init__(self, *, model: str, namespaces: Optional[list[str]] = None):
@@ -84,6 +86,7 @@ class SciSpacyAnnotator(Annotator):
                 )
             return annotations
 
+
 class Grounder:
     """A callable class that grounds a BioEntity to a database identifier.
 
@@ -91,11 +94,25 @@ class Grounder:
     ----------
     namespaces : Optional[list[str]]
         A list of namespaces to consider for grounding (default: None).
+    restrict_mesh_prefix : list[str], optional
+        A list of MESH tree prefixes to restrict grounding to (default: None).
+    annotator : Callable[[str, Optional[str]], list[Tuple[Annotation]]], optional
+        A callable that takes a string and returns a list of annotations
+        (default: GildaAnnotator).
+    grounder_func : Optional[GrounderSignature], optional
+        A callable that takes a string and returns a list of ScoredMatches.
+        If None, defaults to `gilda.ground` (default: None).
 
     Attributes
     ----------
     namespaces : Optional[list[str]]
         A list of namespaces to consider for grounding.
+    restrict_mesh_prefix : list[str]
+        A list of MESH tree prefixes to restrict grounding to.
+    annotator : Callable[[str, Optional[str]], list[Annotation]]
+        A callable that annotates text with named entities.
+    grounder_func : GrounderSignature
+        A callable that grounds text to named entities.
     """
 
     def __init__(

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -39,6 +39,7 @@ class Annotator:
         self,
         *,
         namespaces: Optional[list[str]] = None,
+        mesh_prefix: Optional[str] = "MESH"
     ):
         """Base class for annotators that annotate text with named entities.
 
@@ -48,7 +49,7 @@ class Annotator:
             A list of namespaces to consider for annotation. If None, defaults to ["MESH"].
         """
         if namespaces is None:
-            namespaces = ["MESH"]
+            namespaces = [mesh_prefix]
         self.namespaces = namespaces
 
     def __call__(self, text: str, *, context: str = None) -> list[Annotation]:

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -27,6 +27,13 @@ from scispacy.linking import EntityLinker
 logger = logging.getLogger(__name__)
 
 
+GrounderSignature = Callable[
+    [str, Optional[str], Optional[list[str]], Optional[list[str]]],
+    list[ScoredMatch]
+]
+AnnotatorSignature = Callable[[str, Optional[str]], list[Annotation]]
+
+
 class Annotator:
     def __init__(
         self,

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -148,6 +148,11 @@ class Node:
 
     @property
     def curie(self) -> str:
+        if not self.ns or not self.ns_id:
+            logger.warning(
+                f"{self} does not have a namespace or ID to produce a CURIE with."
+            )
+            return ""
         return curie_to_str(self.ns.lower(), self.ns_id)
 
     @curie.setter

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -208,7 +208,7 @@ class BioEntity(Node):
         self.labels = labels
         self.text: str = text
         self.origin: str = origin
-        self.grounded_term = grounded_term
+        self.grounded_term: str = grounded_term
 
 
 class Condition(BioEntity):

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -180,7 +180,7 @@ class BioEntity(Node):
 
     Parameters
     ----------
-    term: str
+    text: str
         The text term of the bioentity from the given namespace
     labels: list[str]
         The labels of the bioentity
@@ -217,7 +217,7 @@ class Condition(BioEntity):
 
     Parameters
     ----------
-    term: str
+    text: str
         The text term of the bioentity from the given namespace
     labels: list[str]
         The labels of the bioentity
@@ -246,6 +246,39 @@ class Condition(BioEntity):
 
 
 class Intervention(BioEntity):
+    """
+    Represents an intervention in a clinical trial.
+
+    Attributes
+    ----------
+    text : str
+        The text term of the intervention.
+    origin : str
+        The trial CURIE that the intervention is associated with.
+    source : str
+        The source registry of the intervention.
+    labels : list[str], optional
+        Additional labels for the intervention (default: ['intervention']).
+    ns : str, optional
+        The namespace of the intervention (default: None).
+    id : str, optional
+        The ID of the intervention (default: None).
+
+    Parameters
+    ----------
+    text : str
+        The text term of the intervention.
+    origin : str
+        The trial CURIE that the intervention is associated with.
+    source : str
+        The source registry of the intervention.
+    labels : list[str], optional
+        Additional labels for the intervention (default: None).
+    ns : str, optional
+        The namespace of the intervention (default: None).
+    id : str, optional
+        The ID of the intervention (default: None).
+    """
     def __init__(
         self,
         text: str,

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -388,6 +388,7 @@ class Trial(Node):
     ):
         super().__init__(source=source, ns=ns, ns_id=id)
         self.labels: list[str] = ["clinical_trial"]
+        self.phases: list[str] = []
 
         if labels:
             self.labels.extend(labels)

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -293,54 +293,6 @@ class Intervention(BioEntity):
             self.labels.extend(labels)
 
 
-class BioEntity(Node):
-    """Holds information about a biological entity
-
-    Attributes
-    ----------
-    ns: str
-        The namespace of the bioentity
-    id: str
-        The ID of the bioentity
-    source: Optional[str]
-        The source registry of the bioentity
-    term: str
-        The text term of the bioentity from the given namespace
-    origin: Optional[str]
-        The trial CURIE that the bioentity is associated with
-
-    Parameters
-    ----------
-    term: str
-        The text term of the bioentity from the given namespace
-    labels: list[str]
-        The labels of the bioentity
-    origin: str
-        The trial CURIE that the bioentity is associated with
-    source: Optional[str]
-        The source registry of the bioentity.
-    ns: Optional[str]
-        The namespace of the bioentity (default: None).
-    id: Optional[str]
-        The ID of the bioentity (default: None).
-    """
-
-    def __init__(
-        self,
-        term: str,
-        labels: list[str],
-        origin: str,
-        source: str,
-        ns: Optional[str] = None,
-        id: Optional[str] = None,
-    ):
-        super().__init__(ns=ns, id=id, source=source)
-        self.labels = labels
-        self.term: str = term
-        self.origin: str = origin
-        self.source: str = source
-
-
 class Edge:
     """Edge between a trial and a bioentity
 

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -391,6 +391,7 @@ class Trial(Node):
         self.labels: list[str] = ["clinical_trial"]
         self.phases: list[str] = []
         self.start_date: Optional[datetime] = None
+        self.start_date_type: Optional[str] = None
         self.overall_status: Optional[str] = None
         self.why_stopped: Optional[str] = None
 
@@ -403,6 +404,7 @@ class Trial(Node):
         self.primary_outcomes: list[Union[Outcome, str]] = []
         self.secondary_outcomes: list[Union[Outcome, str]] = []
         self.secondary_ids: list[SecondaryId] = []
+        self.references: list[tuple[str, str]] = []
 
     @property
     def conditions(self) -> list[Condition]:

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from typing import Optional, Union
 
 import indra.statements.agent as agent
@@ -389,6 +390,7 @@ class Trial(Node):
         super().__init__(source=source, ns=ns, ns_id=id)
         self.labels: list[str] = ["clinical_trial"]
         self.phases: list[str] = []
+        self.start_date: Optional[datetime] = None
 
         if labels:
             self.labels.extend(labels)

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -391,6 +391,8 @@ class Trial(Node):
         self.labels: list[str] = ["clinical_trial"]
         self.phases: list[str] = []
         self.start_date: Optional[datetime] = None
+        self.overall_status: Optional[str] = None
+        self.why_stopped: Optional[str] = None
 
         if labels:
             self.labels.extend(labels)

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -237,6 +237,7 @@ class Processor:
             "secondary_ids:CURIE[]",
             "source_registry:string",
             "phases:PHASE[]",
+            "start_date:integer",
         ]
 
         store.save_data_as_flatfile(

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -231,7 +231,7 @@ class Processor:
             "labels:LABEL[]",
             "design:DESIGN",
             "conditions:CURIE[]",
-            "interventions:CURIE[]"
+            "interventions:CURIE[]",
             "primary_outcome:OUTCOME[]",
             "secondary_outcome:OUTCOME[]",
             "secondary_ids:CURIE[]",

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -142,9 +142,9 @@ class Processor:
         self.store_samples: bool = store_samples
         self.validate: bool = validate
 
-    def run(self):
+    def run(self, max_pages=None):
         """Processes registry data into a graph structure."""
-        self.fetcher.get_api_data(reload=self.reload_api_data)
+        self.fetcher.get_api_data(reload=self.reload_api_data, max_pages=max_pages)
         self.trials = self.fetcher.raw_data
         #  ground and process bioentities for storing
         self.get_bioentities()

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -237,7 +237,10 @@ class Processor:
             "secondary_ids:CURIE[]",
             "source_registry:string",
             "phases:PHASE[]",
-            "start_date:integer",
+            "start_year:integer",
+            "start_year_anticipated:boolean",  # Fixme: get from API not by estimate
+            "status:string",
+            "why_stopped:boolean"
         ]
 
         store.save_data_as_flatfile(

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -10,7 +10,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 from . import store
 from .config import Config
 from .fetch import Fetcher
-from .ground import ConditionGrounder, InterventionGrounder
+from ..base.ground import Grounder
 from .models import Condition, Intervention, Edge, Trial
 from .transform import Transformer
 from .validate import Validator
@@ -112,7 +112,8 @@ class Processor:
         config: Config,
         fetcher: Fetcher,
         transformer: Transformer,
-        grounders: Tuple[ConditionGrounder, InterventionGrounder],
+        condition_grounder: Grounder,
+        intervention_grounder: Grounder,
         validator: Validator,
         reload_api_data: bool = False,
         store_samples: bool = False,
@@ -129,7 +130,9 @@ class Processor:
 
         self.curie_to_trial: Dict[str, Trial] = {}
 
-        self.grounders: Tuple[ConditionGrounder, InterventionGrounder] = grounders
+        # Grounders for conditions and interventions
+        self.condition_grounder: Grounder = condition_grounder
+        self.intervention_grounder: Grounder = intervention_grounder
 
         self.entities: dict[type, list] = {}
 
@@ -175,13 +178,18 @@ class Processor:
 
     def process_bioentities(self):
         """Processes bioentities by grounding them."""
-        logger.info("Warming up grounder...")
-        self.grounders[0].ground("stuff")
+        logger.info("Warming up grounders...")
+        self.condition_grounder.ground("stuff")
+        self.intervention_grounder.ground("stuff")
         logger.info("Done.")
 
 
-        for type, entities, grounder in zip(self.entities.keys(), self.entities.values(), self.grounders):
-            entity_type = type.__name__.lower()
+        for ent_type, entities, grounder in zip(
+            self.entities.keys(),
+            self.entities.values(),
+            [self.condition_grounder, self.intervention_grounder]
+        ):
+            entity_type = ent_type.__name__.lower()
             entity_iter = tqdm(entities, desc=f'Grounding {entity_type}s', unit=entity_type, unit_scale=True)
 
             for entity in entity_iter:

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -241,6 +241,7 @@ class Processor:
             "start_year_anticipated:boolean",
             "status:string",
             "why_stopped:string",
+            "references:string[]",
         ]
 
         store.save_data_as_flatfile(

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -240,7 +240,7 @@ class Processor:
             "start_year:integer",
             "start_year_anticipated:boolean",  # Fixme: get from API not by estimate
             "status:string",
-            "why_stopped:boolean"
+            "why_stopped:string",
         ]
 
         store.save_data_as_flatfile(

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -236,6 +236,7 @@ class Processor:
             "secondary_outcome:OUTCOME[]",
             "secondary_ids:CURIE[]",
             "source_registry:string",
+            "phases:PHASE[]",
         ]
 
         store.save_data_as_flatfile(

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -238,7 +238,7 @@ class Processor:
             "source_registry:string",
             "phases:PHASE[]",
             "start_year:integer",
-            "start_year_anticipated:boolean",  # Fixme: get from API not by estimate
+            "start_year_anticipated:boolean",
             "status:string",
             "why_stopped:string",
         ]

--- a/src/trialsynth/base/resources/default_config.ini
+++ b/src/trialsynth/base/resources/default_config.ini
@@ -31,7 +31,7 @@ RAW_TRIAL_DATA = clinicaltrials.pkl.gz
 
 API_URL = https://clinicaltrials.gov/api/v2/studies
 
-API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId
+API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase
 
 PROCESSED_DATA = clinical_trials.tsv.gz
 

--- a/src/trialsynth/base/resources/default_config.ini
+++ b/src/trialsynth/base/resources/default_config.ini
@@ -31,7 +31,7 @@ RAW_TRIAL_DATA = clinicaltrials.pkl.gz
 
 API_URL = https://clinicaltrials.gov/api/v2/studies
 
-API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase
+API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule
 
 PROCESSED_DATA = clinical_trials.tsv.gz
 

--- a/src/trialsynth/base/resources/default_config.ini
+++ b/src/trialsynth/base/resources/default_config.ini
@@ -31,7 +31,7 @@ RAW_TRIAL_DATA = clinicaltrials.pkl.gz
 
 API_URL = https://clinicaltrials.gov/api/v2/studies
 
-API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule
+API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule, ReferencesModule
 
 PROCESSED_DATA = clinical_trials.tsv.gz
 

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Iterable, Tuple
 
 from .models import BioEntity, Edge, Node, Trial

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -34,6 +34,7 @@ class Transformer:
             self.transform_secondary_outcome(trial),
             self.transform_secondary_ids(trial),
             trial.source,
+            self.transform_phases(trial.phases)
         )
 
     @staticmethod
@@ -93,6 +94,13 @@ class Transformer:
     def transform_labels(node: Node) -> str:
         """Transforms the type of trial into a string."""
         return join_list_to_str(node.labels)
+
+    @staticmethod
+    def transform_phases(phases: Iterable[str]) -> str:
+        """Transforms the phases of a trial into a string."""
+        if not list(phases):
+            return ""
+        return join_list_to_str([phase.strip() for phase in phases if phase.strip()])
 
     @staticmethod
     def transform_title(trial: Trial) -> str:

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -39,7 +39,8 @@ class Transformer:
             trial.start_date.year if trial.start_date else "",
             self.tranform_anticipated_date(trial),
             trial.overall_status,
-            trial.why_stopped if trial.why_stopped else ""
+            trial.why_stopped if trial.why_stopped else "",
+            self.transform_references(trial.references),
         )
 
     @staticmethod
@@ -51,6 +52,13 @@ class Transformer:
                 return "false"
         else:
             return "false"
+
+    @staticmethod
+    def transform_references(references: list[tuple[str, str]]) -> str:
+        """Transforms a list of references into a string."""
+        if not references:
+            return ""
+        return join_list_to_str([f"{pmid},{ref_type}" for pmid, ref_type in references])
 
     @staticmethod
     def transform_secondary_ids(trial: Trial) -> str:
@@ -90,7 +98,6 @@ class Transformer:
 
         transformed_entities = set(transformed_entities)
         return join_list_to_str(transformed_entities)
-
 
     @staticmethod
     def transform_design(trial: Trial) -> str:

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -44,8 +44,8 @@ class Transformer:
 
     @staticmethod
     def tranform_anticipated_date(trial: Trial) -> str:
-        if trial.start_date is not None:
-            if trial.start_date > datetime.now():
+        if trial.start_date_type is not None:
+            if trial.start_date_type.lower() == "anticipated":
                 return "true"
             else:
                 return "false"

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -34,7 +34,8 @@ class Transformer:
             self.transform_secondary_outcome(trial),
             self.transform_secondary_ids(trial),
             trial.source,
-            self.transform_phases(trial.phases)
+            self.transform_phases(trial.phases),
+            trial.start_date.year if trial.start_date else "",
         )
 
     @staticmethod

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Iterable, Tuple
 
 from .models import BioEntity, Edge, Node, Trial
@@ -36,7 +37,20 @@ class Transformer:
             trial.source,
             self.transform_phases(trial.phases),
             trial.start_date.year if trial.start_date else "",
+            self.tranform_anticipated_date(trial),
+            trial.overall_status,
+            trial.why_stopped if trial.why_stopped else ""
         )
+
+    @staticmethod
+    def tranform_anticipated_date(trial: Trial) -> str:
+        if trial.start_date is not None:
+            if trial.start_date > datetime.now():
+                return "true"
+            else:
+                return "false"
+        else:
+            return "false"
 
     @staticmethod
     def transform_secondary_ids(trial: Trial) -> str:

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -20,7 +20,7 @@ class Transformer:
         -------
         transformed_data: Tuple
             A tuple of the transformed data. In order of title, type, design, conditions, interventions, genes,
-            primary_outcome, secondary_outcome, secondary_ids.
+            primary_outcome, secondary_outcome, secondary_ids, source, phases.
 
         """
         return (

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -108,7 +108,7 @@ class CTFetcher(Fetcher):
 
         for study in data:
             rest_trial = UnflattenedTrial(**study)
-            
+
             trial = Trial(
                 ns="clinicaltrials",
                 id=rest_trial.protocol_section.id_module.nct_id,

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -244,6 +244,15 @@ class CTFetcher(Fetcher):
                 for s in secondary_info
             ]
 
+            # References
+            references = rest_trial.protocol_section.references_module.references
+            if references:
+                any_references = True
+
+            trial.references += [
+                (ref.pmid, ref.type) for ref in references if ref.pmid is not None
+            ]
+
             trial.source = self.config.registry
 
             trials.append(trial)

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -120,6 +120,11 @@ class CTFetcher(Fetcher):
             if study_type:
                 trial.labels.append(study_type.strip().lower())
 
+            phases = rest_trial.protocol_section.design_module.phases
+
+            if phases:
+                trial.labels.extend([phase.strip().lower() for phase in phases])
+
             design_info = rest_trial.protocol_section.design_module.design_info
             trial.design = DesignInfo(
                 purpose=design_info.purpose,

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -134,7 +134,6 @@ class CTFetcher(Fetcher):
                 rest_trial.protocol_section.status_module.start_date_struct.date
             )
             if start_date_str is not None:
-                any_start_date = True
                 trial.start_date = datetime.datetime.strptime(
                     start_date_str,
                     "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -1,4 +1,5 @@
 """Gets Clinicaltrials.gov data from REST API or saved file"""
+import datetime
 
 import requests
 from overrides import overrides
@@ -124,6 +125,17 @@ class CTFetcher(Fetcher):
 
             if phases:
                 trial.phases.extend([phase.strip().lower() for phase in phases])
+
+            # Start date, either %Y-%m-%d or %Y-%m"
+            start_date_str = (
+                rest_trial.protocol_section.status_module.start_date_struct.date
+            )
+            if start_date_str is not None:
+                any_start_date = True
+                trial.start_date = datetime.datetime.strptime(
+                    start_date_str,
+                    "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",
+                )
 
             design_info = rest_trial.protocol_section.design_module.design_info
             trial.design = DesignInfo(

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -52,7 +52,7 @@ class CTFetcher(Fetcher):
         self.total_pages = 0
 
     @overrides
-    def get_api_data(self, reload: bool = False, *kwargs) -> None:
+    def get_api_data(self, reload: bool = False, max_pages=None, *kwargs) -> None:
         trial_path = self.config.raw_data_path
         if trial_path.is_file() and not reload:
             self.load_saved_data()
@@ -63,11 +63,11 @@ class CTFetcher(Fetcher):
         try:
             self._read_next_page()
 
-            pages = self.total_pages
+            pages = self.total_pages if max_pages is None else max_pages
             page_size = self.api_parameters.get("pageSize")
             with tqdm(
                 desc="Downloading ClinicalTrials.gov trials",
-                total=int(pages * page_size),
+                total=int(pages * page_size) if max_pages is None else max_pages * page_size,
                 unit="trial",
                 unit_scale=True,
             ) as pbar:

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -123,7 +123,7 @@ class CTFetcher(Fetcher):
             phases = rest_trial.protocol_section.design_module.phases
 
             if phases:
-                trial.labels.extend([phase.strip().lower() for phase in phases])
+                trial.phases.extend([phase.strip().lower() for phase in phases])
 
             design_info = rest_trial.protocol_section.design_module.design_info
             trial.design = DesignInfo(

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -114,13 +114,16 @@ class CTFetcher(Fetcher):
                 id=rest_trial.protocol_section.id_module.nct_id,
             )
 
+            # Brief Title
             trial.title = rest_trial.protocol_section.id_module.brief_title
 
+            # Study Type e.g. "Interventional", "Observational"
             study_type = rest_trial.protocol_section.design_module.study_type
 
             if study_type:
                 trial.labels.append(study_type.strip().lower())
 
+            # Phases e.g. "PHASE1", "PHASE2|PHASE3", "EARLY_PHASE_1", "NA"
             phases = rest_trial.protocol_section.design_module.phases
 
             if phases:
@@ -137,21 +140,24 @@ class CTFetcher(Fetcher):
                     "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",
                 )
 
+            # Design information
             design_info = rest_trial.protocol_section.design_module.design_info
             trial.design = DesignInfo(
-                purpose=design_info.purpose,
-                allocation=design_info.allocation,
-                masking=design_info.masking_info.masking,
+                purpose=design_info.purpose,  # E.g. "TREATMENT"
+                allocation=design_info.allocation,  # E.g. "RANDOMIZED"
+                masking=design_info.masking_info.masking,  # E.g. "NONE"
                 assignment=(
-                    design_info.intervention_assignment
+                    design_info.intervention_assignment  # E.g. "CROSSOVER"
                     if design_info.intervention_assignment
                     else design_info.observation_assignment
                 ),
             )
 
+            # Assigned conditions Mesh terms
             condition_meshes = (
                 rest_trial.derived_section.condition_browse_module.condition_meshes
             )
+            # Conditions
             conditions = (
                 rest_trial.protocol_section.conditions_module.conditions
             )
@@ -176,9 +182,11 @@ class CTFetcher(Fetcher):
                 ]
             )
 
+            # Assigned intervention text
             intervention_arms = (
                 rest_trial.protocol_section.arms_interventions_module.arms_interventions
             )
+            # Assigned intervention Mesh terms
             intervention_meshes = (
                 rest_trial.derived_section.intervention_browse_module.intervention_meshes
             )

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -139,6 +139,15 @@ class CTFetcher(Fetcher):
                     "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",
                 )
 
+            # Overall status e.g. "COMPLETED", "RECRUITING", "TERMINATED"
+            overall_status = rest_trial.protocol_section.status_module.overall_status
+            trial.overall_status = overall_status.strip().lower()
+
+            # Why stopped e.g. "REASON_FOR_TERMINATION"
+            why_stopped = rest_trial.protocol_section.status_module.why_stopped
+            if why_stopped:
+                trial.why_stopped = why_stopped.strip().lower()
+
             # Design information
             design_info = rest_trial.protocol_section.design_module.design_info
             trial.design = DesignInfo(

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -133,11 +133,13 @@ class CTFetcher(Fetcher):
             start_date_str = (
                 rest_trial.protocol_section.status_module.start_date_struct.date
             )
+            date_type = rest_trial.protocol_section.status_module.start_date_struct.date_type
             if start_date_str is not None:
                 trial.start_date = datetime.datetime.strptime(
                     start_date_str,
                     "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",
                 )
+                trial.start_date_type = date_type.strip().lower() if date_type else None
 
             # Overall status e.g. "COMPLETED", "RECRUITING", "TERMINATED"
             overall_status = rest_trial.protocol_section.status_module.overall_status

--- a/src/trialsynth/clinical_trials_dot_gov/process.py
+++ b/src/trialsynth/clinical_trials_dot_gov/process.py
@@ -16,6 +16,21 @@ class CTProcessor(Processor):
         condition_grounder: Grounder = CTConditionGrounder(),
         intervention_grounder: Grounder = CTInterventionGrounder(),
     ):
+        """Initialize the ClinicalTrials.gov processor.
+
+        Parameters
+        ----------
+        reload_api_data :
+            If True, the API data will be reloaded from the ClinicalTrials.gov REST API.
+        store_samples :
+            If True, the processor will store sample data for validation.
+        validate :
+            If True, the processor will validate the data.
+        condition_grounder :
+            A grounder to use for grounding conditions. Defaults to CTConditionGrounder().
+        intervention_grounder :
+            A grounder to use for grounding interventions. Defaults to CTInterventionGrounder().
+        """
         super().__init__(
             config=CTConfig(),
             fetcher=CTFetcher(CTConfig()),

--- a/src/trialsynth/clinical_trials_dot_gov/process.py
+++ b/src/trialsynth/clinical_trials_dot_gov/process.py
@@ -1,4 +1,5 @@
 from ..base.process import Processor
+from ..base.ground import Grounder
 from .config import CTConfig
 from .fetch import CTFetcher
 from .ground import CTConditionGrounder, CTInterventionGrounder
@@ -7,13 +8,21 @@ from .validate import CTValidator
 
 
 class CTProcessor(Processor):
-    def __init__(self, reload_api_data: bool, store_samples: bool, validate: bool):
+    def __init__(
+        self,
+        reload_api_data: bool,
+        store_samples: bool,
+        validate: bool,
+        condition_grounder: Grounder = CTConditionGrounder(),
+        intervention_grounder: Grounder = CTInterventionGrounder(),
+    ):
         super().__init__(
             config=CTConfig(),
             fetcher=CTFetcher(CTConfig()),
             transformer=CTTransformer(),
             validator=CTValidator(),
-            grounders=(CTConditionGrounder(), CTInterventionGrounder()),
+            condition_grounder=condition_grounder,
+            intervention_grounder=intervention_grounder,
             reload_api_data=reload_api_data,
             store_samples=store_samples,
             validate=validate,

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -52,6 +52,7 @@ class DesignModule(BaseModel):
 
     study_type: str = Field(alias="studyType", default=None)
     design_info: DesignInfo = Field(alias="designInfo", default=DesignInfo())
+    phases: list[str] = Field(alias="phases", default=[])
 
 
 class Reference(BaseModel):

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -56,8 +56,11 @@ class DesignModule(BaseModel):
 
 
 class Reference(BaseModel):
+    # See: https://clinicaltrials.gov/policy/protocol-definitions#references
 
-    pmid: str  # these are tagged as relevant by the author, but not necessarily about the trial
+    pmid: str = Field(alias="pmid", default=None)  # Reference PMID
+    type: str = Field(alias="type", default=None)  # One of BACKGROUND, RESULT, DERIVED
+    citation: str = Field(alias="citation", default=None)
 
 
 class ReferencesModule(BaseModel):

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -30,7 +30,7 @@ class StatusModule(BaseModel):
     start_date_struct: StartDateStruct = Field(
         alias="startDateStruct", default=StartDateStruct()
     )
-    overall_status: str = Field(alias="overallStatus")
+    overall_status: str = Field(alias="overallStatus", default=None)
     why_stopped: str = Field(alias="whyStopped", default=None)
 
 
@@ -114,6 +114,9 @@ class ProtocolSection(BaseModel):
     )
     outcomes_module: OutcomesModule = Field(
         alias="outcomesModule", default=OutcomesModule()
+    )
+    status_module: StatusModule = Field(
+        alias="statusModule", default=StatusModule()
     )
 
 

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -65,7 +65,7 @@ class Reference(BaseModel):
 
 class ReferencesModule(BaseModel):
 
-    references: list[Reference | dict] = Field(alias="references", default=[])
+    references: list[Reference] = Field(alias="references", default=[])
 
 
 class Intervention(BaseModel):

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -118,6 +118,9 @@ class ProtocolSection(BaseModel):
     status_module: StatusModule = Field(
         alias="statusModule", default=StatusModule()
     )
+    references_module: ReferencesModule = Field(
+        alias="referencesModule", default=ReferencesModule()
+    )
 
 
 class DerivedSection(BaseModel):

--- a/src/trialsynth/who/process.py
+++ b/src/trialsynth/who/process.py
@@ -16,10 +16,8 @@ class WhoProcessor(Processor):
             fetcher=WhoFetcher(config),
             transformer=WhoTransformer(),
             validator=WhoValidator(),
-            grounders=(
-                WhoConditionGrounder(),
-                WhoInterventionGrounder(),
-            ),
+            condition_grounder=WhoConditionGrounder(),
+            intervention_grounder=WhoInterventionGrounder(),
             reload_api_data=reload_api_data,
             store_samples=store_samples,
             validate=validate,


### PR DESCRIPTION
This PR add some new default fields to save from the REST API response for clinicaltrials.gov as well as some other changes that makes it easier to subclass the Grounder and Annotator classes such that they can be passed along into the run portion of the pipeline and be used for grounding.