### PR TITLE
More fields and update grounding logic

### DIFF
--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -1,7 +1,7 @@
 import copy
 import logging
 import warnings
-from typing import Iterator, Optional, Callable
+from typing import Iterator, Optional, Callable, Literal
 
 nmslib_logger = logging.getLogger('nmslib')
 nmslib_logger.setLevel(logging.ERROR)
@@ -35,7 +35,7 @@ class Annotator:
         self,
         *,
         namespaces: Optional[list[str]] = None,
-        mesh_prefix: Optional[str] = "MESH"
+        mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
     ):
         """Base class for annotators that annotate text with named entities.
 
@@ -43,6 +43,9 @@ class Annotator:
         ----------
         namespaces : Optional[list[str]]
             A list of namespaces to consider for annotation. If None, defaults to ["MESH"].
+        mesh_prefix : Optional[Literal["mesh", "MESH"]]
+            The prefix to use for MESH grounding. If None, defaults to "MESH". Use
+            this to specify the capitalization of the MESH prefix for grounding.
         """
         if namespaces is None:
             namespaces = [mesh_prefix]
@@ -99,7 +102,7 @@ class Grounder:
     grounder_func : Optional[GrounderSignature], optional
         A callable that takes a string and returns a list of ScoredMatches.
         If None, defaults to `gilda.ground` (default: None).
-    mesh_prefix : Optional[str], optional. Defaults to "MESH".
+    mesh_prefix : Optional[Literal["mesh", "MESH"]]
         The prefix to use for MESH grounding. If None, defaults to "MESH". Use
         this to specify the capitalization of the MESH prefix for grounding.
 
@@ -113,10 +116,9 @@ class Grounder:
         A callable that annotates text with named entities.
     grounder_func : GrounderSignature
         A callable that grounds text to named entities.
-    mesh_prefix : str
+    mesh_prefix : Optional[Literal["mesh", "MESH"]]
         The prefix to use for MESH grounding. Should match the capitalization
-        used in by the grounding function, typically this would be "MESH" or
-        "mesh".
+        returned by the grounding function.
     """
 
     def __init__(
@@ -126,7 +128,7 @@ class Grounder:
         restrict_mesh_prefix: list[str] = None,
         annotator: AnnotatorSignature = GildaAnnotator(),
         grounder_func: Optional[GrounderSignature] = None,
-        mesh_prefix: Optional[str] = "MESH"
+        mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
     ):
         self.namespaces: Optional[list[str]] = namespaces
         self.restrict_mesh_prefix = restrict_mesh_prefix
@@ -238,7 +240,7 @@ class ConditionGrounder(Grounder):
         namespaces: Optional[list[str]] = None,
         annotator: Optional[AnnotatorSignature] = None,
         grounder_func: Optional[GrounderSignature] = None,
-        mesh_prefix: Optional[str] = "MESH"
+        mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
     ):
         if namespaces is None:
             namespaces = CONDITION_NS
@@ -259,7 +261,7 @@ class InterventionGrounder(Grounder):
         namespaces: Optional[list[str]] = None,
         annotator: Optional[AnnotatorSignature] = None,
         grounder_func: Optional[GrounderSignature] = None,
-        mesh_prefix: Optional[str] = "MESH"
+        mesh_prefix: Literal["MESH", "mesh"] = "MESH"
     ):
         if namespaces is None:
             namespaces = INTERVENTION_NS

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -1,8 +1,7 @@
 import copy
 import logging
 import warnings
-from collections import defaultdict
-from typing import Iterator, Optional, Callable, Tuple 
+from typing import Iterator, Optional, Callable
 
 nmslib_logger = logging.getLogger('nmslib')
 nmslib_logger.setLevel(logging.ERROR)
@@ -19,10 +18,7 @@ from .util import (
     must_override
 )
 
-import scispacy
 import spacy
-from scispacy.abbreviation import AbbreviationDetector
-from scispacy.linking import EntityLinker
 
 logger = logging.getLogger(__name__)
 

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -197,7 +197,9 @@ class Grounder:
             )
 
     def ground(
-        self, entity: BioEntity, context: Optional[str] = None
+        self,
+        entity: BioEntity,
+        context: Optional[str] = None
     ) -> Iterator[BioEntity]:
         """Ground a BioEntity to a CURIE."""
         entity = self.preprocess(entity)
@@ -225,6 +227,13 @@ class Grounder:
                 annotations = self.annotator(entity.text, context=context)
                 for annotation in annotations:
                     yield from self._yield_entity(entity, annotation.matches[0])
+                # If no matches are found, we try to annotate the description if it exists
+                if entity.description:
+                    annotations = self.annotator(
+                        entity.description, context=context
+                    )
+                    for annotation in annotations:
+                        yield from self._yield_entity(entity, annotation.matches[0])
 
 
 class ConditionGrounder(Grounder):

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -423,7 +423,7 @@ class Trial(Node):
 
         self.title: Optional[str] = None
         self.brief_summary: Optional[str] = None
-        self.description: Optional[str] = None
+        self.detailed_description: Optional[str] = None
         self.design: DesignInfo = DesignInfo()
         self.entities: list[BioEntity] = []
         self.primary_outcomes: list[Union[Outcome, str]] = []

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -173,7 +173,11 @@ class BioEntity(Node):
         The source registry of the bioentity
     text: str
         The free-text of the bioentity
-    grounded_term: str
+    description: Optional[str]
+        The description of the bioentity
+    labels: list[str]
+        The labels of the bioentity
+    grounded_term: Optional[str]
         The entry-term for the grounded bioentity from the given namespace
     origin: Optional[str]
         The trial CURIE that the bioentity is associated with
@@ -200,6 +204,7 @@ class BioEntity(Node):
         labels: list[str],
         origin: str,
         source: str,
+        description: Optional[str] = None,
         ns: Optional[str] = None,
         id: Optional[str] = None,
         grounded_term: Optional[str] = None
@@ -207,6 +212,7 @@ class BioEntity(Node):
         super().__init__(ns=ns, ns_id=id, source=source)
         self.labels = labels
         self.text: str = text
+        self.description: str = description
         self.origin: str = origin
         self.grounded_term: str = grounded_term
 
@@ -219,6 +225,8 @@ class Condition(BioEntity):
     ----------
     text: str
         The text term of the bioentity from the given namespace
+    description: Optional[str]
+        The description of the bioentity (default: None).
     labels: list[str]
         The labels of the bioentity
     origin: str
@@ -236,11 +244,20 @@ class Condition(BioEntity):
         text: str,
         origin: str,
         source: str,
+        description: Optional[str] = None,
         labels: Optional[list[str]] = None,
         ns: Optional[str] = None,
         id: Optional[str] = None,
     ):
-        super().__init__(text=text, labels=['condition'], origin=origin, source=source, ns=ns, id=id)
+        super().__init__(
+            text=text,
+            labels=['condition'],
+            origin=origin,
+            source=source,
+            ns=ns,
+            id=id,
+            description=description,
+        )
         if labels:
             self.labels.extend(labels)
 
@@ -257,6 +274,8 @@ class Intervention(BioEntity):
         The trial CURIE that the intervention is associated with.
     source : str
         The source registry of the intervention.
+    description : Optional[str]
+        The description of the intervention (default: None).
     labels : list[str], optional
         Additional labels for the intervention (default: ['intervention']).
     ns : str, optional
@@ -284,11 +303,20 @@ class Intervention(BioEntity):
         text: str,
         origin: str,
         source: str,
+        description: Optional[str] = None,
         labels: Optional[list[str]] = None,
         ns: Optional[str] = None,
         id: Optional[str] = None,
     ):
-        super().__init__(text=text, labels=['intervention'], origin=origin, source=source, ns=ns, id=id)
+        super().__init__(
+            text=text,
+            description=description,
+            labels=['intervention'],
+            origin=origin,
+            source=source,
+            ns=ns,
+            id=id
+        )
         if labels:
             self.labels.extend(labels)
 
@@ -382,6 +410,11 @@ class Trial(Node):
         self.phases: list[str] = []
         self.start_date: Optional[datetime] = None
         self.start_date_type: Optional[str] = None
+        self.completion_date: Optional[datetime] = None
+        self.completion_date_type: Optional[str] = None
+        self.primary_completion_date: Optional[datetime] = None
+        self.primary_completion_date_type: Optional[str] = None
+        self.last_update_submit_date: Optional[datetime] = None
         self.overall_status: Optional[str] = None
         self.why_stopped: Optional[str] = None
 
@@ -389,6 +422,8 @@ class Trial(Node):
             self.labels.extend(labels)
 
         self.title: Optional[str] = None
+        self.brief_summary: Optional[str] = None
+        self.description: Optional[str] = None
         self.design: DesignInfo = DesignInfo()
         self.entities: list[BioEntity] = []
         self.primary_outcomes: list[Union[Outcome, str]] = []

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -336,6 +336,8 @@ class Trial(Node):
         The source registry of the trial (default: None).
     title: str
         The title of the trial
+    official_title: Optional[str]
+        The official title of the trial (default: None).
     design: Union[DesignInfo, str]
         The design information of the trial
     conditions: list
@@ -385,6 +387,7 @@ class Trial(Node):
             self.labels.extend(labels)
 
         self.title: Optional[str] = None
+        self.official_title: Optional[str] = None
         self.brief_summary: Optional[str] = None
         self.detailed_description: Optional[str] = None
         self.design: DesignInfo = DesignInfo()

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -321,43 +321,6 @@ class Intervention(BioEntity):
             self.labels.extend(labels)
 
 
-class Edge:
-    """Edge between a trial and a bioentity
-
-    Attributes
-    ----------
-    bio_ent_curie: str
-        The CURIE of the bioentity
-    trial_curie: str
-        The CURIE of the trial
-    rel_type: str
-        The type of relationship between the bioentity and the trial
-    rel_type_curie: str
-        The CURIE of the relationship type
-    source: str
-        The source of the relationship
-    """
-
-    def __init__(
-        self, bio_ent_curie: str, trial_curie: str, rel_type: str, source: str
-    ):
-        self.bio_ent_curie = bio_ent_curie
-        self.trial_curie = trial_curie
-        self.rel_type = rel_type
-        self.source = source
-
-        rel_type_to_curie = {
-            "has_condition": "debio:0000036",
-            "has_intervention": "debio:0000035",
-        }
-        if rel_type not in rel_type_to_curie.keys():
-            logger.warning(
-                f"Relationship type: {rel_type} not defined. Defaulting to empty string for curie"
-            )
-            self.rel_type_curie = ""
-        else:
-            self.rel_type_curie = rel_type_to_curie[rel_type]
-
 class Trial(Node):
     """Holds information about a clinical trial
 

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -165,7 +165,7 @@ class Processor:
         """Extracts bioentities from trials and creates a dictionary of trial CURIEs to trials."""
 
         for trial in self.trials:
-            
+
             self.curie_to_trial[trial.curie] = trial
 
             for entity in trial.entities:
@@ -288,13 +288,13 @@ class Processor:
         -------
         None
         """
-        curie_to_entity = {}
-
+        entities = set()
         for trial in self.trials:
             for entity in trial.entities:
-                curie_to_entity[entity.curie] = entity
-
-        entities = [self.transformer.flatten_bioentity(entity) for entity in curie_to_entity.values()]
+                flat_entity = self.transformer.flatten_bioentity(entity)
+                entities.add(flat_entity)
+        # Sort entities by entity CURIE and trial CURIE
+        entities = sorted(entities, key=lambda x: (x[0], x[-1]))
         store.save_data_as_flatfile(
             entities,
             path=path,
@@ -303,6 +303,7 @@ class Processor:
                 "term:string",
                 "labels:LABEL[]",
                 "source_registry:string",
+                "trial:CURIE",
             ],
             sample_path=sample_path,
             num_samples=self.config.num_sample_entries,

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -241,6 +241,7 @@ class Processor:
         headers = [
             "curie:CURIE",
             "title:string",
+            "official_title:string",
             "brief_summary:string",
             "detailed_description:string",
             "labels:LABEL[]",

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -195,8 +195,13 @@ class Processor:
             for entity in entity_iter:
                 with logging_redirect_tqdm():
                     trial = self.curie_to_trial[entity.origin]
+                    context = trial.title
+                    if trial.brief_summary:
+                        context += "\n" + trial.brief_summary
+                    if trial.detailed_description:
+                        context += "\n" + trial.detailed_description
 
-                    entities = list(grounder(entity, trial.title))
+                    entities = list(grounder(entity, context=context))
 
                     trial.entities.extend(entities)
 
@@ -236,6 +241,8 @@ class Processor:
         headers = [
             "curie:CURIE",
             "title:string",
+            "brief_summary:string",
+            "detailed_description:string",
             "labels:LABEL[]",
             "design:DESIGN",
             "conditions:CURIE[]",
@@ -247,6 +254,11 @@ class Processor:
             "phases:PHASE[]",
             "start_year:integer",
             "start_year_anticipated:boolean",
+            "primary_completion_year:integer",
+            "primary_completion_year_type:string",
+            "completion_year:integer",
+            "completion_year_type:string",
+            "last_update_submit_year:integer",
             "status:string",
             "why_stopped:string",
             "references:string[]",

--- a/src/trialsynth/base/resources/default_config.ini
+++ b/src/trialsynth/base/resources/default_config.ini
@@ -31,7 +31,7 @@ RAW_TRIAL_DATA = clinicaltrials.pkl.gz
 
 API_URL = https://clinicaltrials.gov/api/v2/studies
 
-API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule, ReferencesModule
+API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule, ReferencesModule, DescriptionModule
 
 PROCESSED_DATA = clinical_trials.tsv.gz
 

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -25,7 +25,9 @@ class Transformer:
         """
         return (
             trial.curie,
-            self.transform_title(trial),
+            self.transform_plain_text(trial.title),
+            self.transform_plain_text(trial.brief_summary or ""),
+            self.transform_plain_text(trial.detailed_description or ""),
             self.transform_labels(trial),
             self.transform_design(trial),
             self.transform_entities(trial.conditions),
@@ -37,6 +39,11 @@ class Transformer:
             self.transform_phases(trial.phases),
             trial.start_date.year if trial.start_date else "",
             self.tranform_anticipated_date(trial),
+            trial.primary_completion_date.year if trial.primary_completion_date else "",
+            trial.primary_completion_date_type or "",
+            trial.completion_date.year if trial.completion_date else "",
+            trial.completion_date_type or "",
+            trial.last_update_submit_date.year if trial.last_update_submit_date else "",
             trial.overall_status,
             trial.why_stopped if trial.why_stopped else "",
             self.transform_references(trial.references),
@@ -124,9 +131,9 @@ class Transformer:
         return join_list_to_str([phase.strip() for phase in phases if phase.strip()])
 
     @staticmethod
-    def transform_title(trial: Trial) -> str:
+    def transform_plain_text(txt: str) -> str:
         """Transforms the title of a trial into a string."""
-        return trial.title.strip()
+        return txt.strip()
 
     def flatten_bioentity(
         self, entity: BioEntity

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -26,6 +26,7 @@ class Transformer:
         return (
             trial.curie,
             self.transform_plain_text(trial.title),
+            self.transform_plain_text(trial.official_title or ""),
             self.transform_plain_text(trial.brief_summary or ""),
             self.transform_plain_text(trial.detailed_description or ""),
             self.transform_labels(trial),

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -137,7 +137,7 @@ class Transformer:
 
     def flatten_bioentity(
         self, entity: BioEntity
-    ) -> Tuple[str, str, str, str]:
+    ) -> Tuple[str, str, str, str, str]:
         """Flattens a BioEntity into a tuple of strings.
 
         Parameters
@@ -147,7 +147,7 @@ class Transformer:
 
         Returns
         -------
-        Tuple[str, str, str, str]
+        Tuple[str, str, str, str, str]
             A tuple of the flattened BioEntity. In order of curie, term, source.
         """
         return (
@@ -155,10 +155,11 @@ class Transformer:
             entity.grounded_term,
             self.transform_labels(entity),
             entity.source,
+            entity.origin,
         )
 
     @staticmethod
-    def flatten_edge(edge: Edge) -> Tuple[str, str, str, str, str]:
+    def flatten_edge(edge: Edge) -> Tuple[str, str, str, str]:
         """Flattens an Edge into a tuple of strings.
 
         Parameters
@@ -168,7 +169,7 @@ class Transformer:
 
         Returns
         -------
-        Tuple[str, str, str, str, str]
+        Tuple[str, str, str, str]
             A tuple of the flattened Edge. In order of trial_curie, bio_ent_curie, rel_type, rel_type_curie, source.
         """
         return (

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -271,3 +271,13 @@ class CTFetcher(Fetcher):
             trials.append(trial)
 
         return trials
+
+
+def _parse_date(date_str: str) -> datetime.datetime:
+    """Parse a date string into a datetime object."""
+    if not date_str:
+        return None
+    try:
+        return datetime.datetime.strptime(date_str, "%Y-%m-%d")
+    except ValueError:
+        return datetime.datetime.strptime(date_str, "%Y-%m")

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -127,6 +127,7 @@ class CTFetcher(Fetcher):
 
             # Brief Title, summary and detailed description
             trial.title = rest_trial.protocol_section.id_module.brief_title
+            trial.official_title = rest_trial.protocol_section.id_module.official_title
             trial.brief_summary = rest_trial.protocol_section.description_module.brief_summary
             trial.detailed_description = (
                 rest_trial.protocol_section.description_module.detailed_description

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -128,7 +128,7 @@ class CTFetcher(Fetcher):
             # Brief Title, summary and detailed description
             trial.title = rest_trial.protocol_section.id_module.brief_title
             trial.brief_summary = rest_trial.protocol_section.description_module.brief_summary
-            trial.description = (
+            trial.detailed_description = (
                 rest_trial.protocol_section.description_module.detailed_description
             )
 

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -182,7 +182,7 @@ class CTFetcher(Fetcher):
                 rest_trial.protocol_section.status_module.last_update_submit_date
             )
             if last_update_date_str is not None:
-                trial.last_update_date = _parse_date(last_update_date_str)
+                trial.last_update_submit_date = _parse_date(last_update_date_str)
 
             # Overall status e.g. "COMPLETED", "RECRUITING", "TERMINATED"
             overall_status = rest_trial.protocol_section.status_module.overall_status

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -125,8 +125,12 @@ class CTFetcher(Fetcher):
                 id=rest_trial.protocol_section.id_module.nct_id,
             )
 
-            # Brief Title
+            # Brief Title, summary and detailed description
             trial.title = rest_trial.protocol_section.id_module.brief_title
+            trial.brief_summary = rest_trial.protocol_section.description_module.brief_summary
+            trial.description = (
+                rest_trial.protocol_section.description_module.detailed_description
+            )
 
             # Study Type e.g. "Interventional", "Observational"
             study_type = rest_trial.protocol_section.design_module.study_type

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -247,6 +247,7 @@ class CTFetcher(Fetcher):
             trial.entities.extend([
                 Intervention(
                     text=i.name,
+                    description=i.description,
                     labels=[i.intervention_type],
                     origin=trial.curie,
                     source=self.config.registry,

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -140,17 +140,45 @@ class CTFetcher(Fetcher):
             if phases:
                 trial.phases.extend([phase.strip().lower() for phase in phases])
 
-            # Start date, either %Y-%m-%d or %Y-%m"
+            # Start date, completion date, primary completion date, last update date
             start_date_str = (
                 rest_trial.protocol_section.status_module.start_date_struct.date
             )
-            date_type = rest_trial.protocol_section.status_module.start_date_struct.date_type
+            start_date_type = rest_trial.protocol_section.status_module.start_date_struct.date_type
             if start_date_str is not None:
-                trial.start_date = datetime.datetime.strptime(
-                    start_date_str,
-                    "%Y-%m-%d" if start_date_str.count("-") == 2 else "%Y-%m",
+                trial.start_date = _parse_date(start_date_str)
+                trial.start_date_type = start_date_type.strip().lower() if start_date_type else None
+            completion_date_str = (
+                rest_trial.protocol_section.status_module.completion_date_struct.date
+            )
+            completion_date_type = (
+                rest_trial.protocol_section.status_module.completion_date_struct.date_type
+            )
+            if completion_date_str is not None:
+                trial.completion_date = _parse_date(completion_date_str)
+                trial.completion_date_type = (
+                    completion_date_type.strip().lower() if completion_date_type else None
                 )
-                trial.start_date_type = date_type.strip().lower() if date_type else None
+            primary_completion_date_str = (
+                rest_trial.protocol_section.status_module.primary_completion_date_struct.date
+            )
+            primary_completion_date_type = (
+                rest_trial.protocol_section.status_module.primary_completion_date_struct.date_type
+            )
+            if primary_completion_date_str is not None:
+                trial.primary_completion_date = _parse_date(
+                    primary_completion_date_str
+                )
+                trial.primary_completion_date_type = (
+                    primary_completion_date_type.strip().lower()
+                    if primary_completion_date_type
+                    else None
+                )
+            last_update_date_str = (
+                rest_trial.protocol_section.status_module.last_update_submit_date
+            )
+            if last_update_date_str is not None:
+                trial.last_update_date = _parse_date(last_update_date_str)
 
             # Overall status e.g. "COMPLETED", "RECRUITING", "TERMINATED"
             overall_status = rest_trial.protocol_section.status_module.overall_status

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -1,3 +1,9 @@
+"""
+Models for the unflattened response from the clinicaltrials.gov REST API.
+
+See https://clinicaltrials.gov/data-api/about-api/study-data-structure
+for more details on the structure of the response.
+"""
 from pydantic import BaseModel, Field
 from datetime import datetime
 

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -145,7 +145,7 @@ class ProtocolSection(BaseModel):
     conditions_module: ConditionsModule = Field(
         alias="conditionsModule", default=ConditionsModule()
     )
-    description_module: BaseModel = Field(
+    description_module: DescriptionModule = Field(
         alias="descriptionModule", default=DescriptionModule()
     )
     design_module: DesignModule = Field(alias="designModule", default=DesignModule())

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -72,6 +72,7 @@ class Intervention(BaseModel):
 
     name: str = Field(default=None)
     intervention_type: str = Field(alias="type")
+    description: str = Field(default=None)
 
 
 class ArmsInterventionsModule(BaseModel):

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -17,6 +17,7 @@ class IDModule(BaseModel):
 
     nct_id: str = Field(alias="nctId")
     brief_title: str = Field(alias="briefTitle")
+    official_title: str = Field(alias="officialTitle", default=None)
     secondary_ids: list[SecondaryID] = Field(alias="secondaryIds", default=[])
 
 

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -5,7 +5,6 @@ See https://clinicaltrials.gov/data-api/about-api/study-data-structure
 for more details on the structure of the response.
 """
 from pydantic import BaseModel, Field
-from datetime import datetime
 
 
 class SecondaryID(BaseModel):
@@ -28,7 +27,7 @@ class ConditionsModule(BaseModel):
 
 class DateStruct(BaseModel):
 
-    date: datetime = Field(default=None)
+    date: str = Field(default=None)
     date_type: str = Field(alias="type", default=None)
 
 
@@ -55,7 +54,9 @@ class StatusModule(BaseModel):
                     "adverse events (for example, last participant’s last "
                     "visit)",
     )
-    last_update_submit_date: datetime = Field(alias="lastUpdateSubmitDate", default=None)
+    last_update_submit_date: str = Field(
+        alias="lastUpdateSubmitDate", default=None
+    )
     overall_status: str = Field(alias="overallStatus", default=None)
     why_stopped: str = Field(alias="whyStopped", default=None)
 

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -105,11 +105,20 @@ class OutcomesModule(BaseModel):
     secondary_outcome: list[Outcome] = Field(alias="secondaryOutcomes", default=[])
 
 
+class DescriptionModule(BaseModel):
+
+    brief_summary: str = Field(alias="briefSummary", default=None)
+    detailed_description: str = Field(alias="detailedDescription", default=None)
+
+
 class ProtocolSection(BaseModel):
 
     id_module: IDModule = Field(alias="identificationModule")
     conditions_module: ConditionsModule = Field(
         alias="conditionsModule", default=ConditionsModule()
+    )
+    description_module: BaseModel = Field(
+        alias="descriptionModule", default=DescriptionModule()
     )
     design_module: DesignModule = Field(alias="designModule", default=DesignModule())
     arms_interventions_module: ArmsInterventionsModule = Field(

--- a/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
+++ b/src/trialsynth/clinical_trials_dot_gov/rest_api_response_models.py
@@ -1,4 +1,5 @@
 from pydantic import BaseModel, Field
+from datetime import datetime
 
 
 class SecondaryID(BaseModel):
@@ -19,17 +20,36 @@ class ConditionsModule(BaseModel):
     conditions: list[str] = Field(default=[])
 
 
-class StartDateStruct(BaseModel):
+class DateStruct(BaseModel):
 
-    date: str = Field(default=None)
+    date: datetime = Field(default=None)
     date_type: str = Field(alias="type", default=None)
 
 
 class StatusModule(BaseModel):
 
-    start_date_struct: StartDateStruct = Field(
-        alias="startDateStruct", default=StartDateStruct()
+    start_date_struct: DateStruct = Field(
+        alias="startDateStruct", default=DateStruct()
     )
+    primary_completion_date_struct: DateStruct = Field(
+        alias="primaryCompletionDateStruct",
+        default=DateStruct(),
+        description="The date that the final participant was examined or "
+                    "received an intervention for the purposes of final "
+                    "collection of data for the primary outcome"
+    )
+    # Also known as "Study Completion Date", see:
+    # https://clinicaltrials.gov/policy/protocol-definitions#LastFollowUpDate
+    completion_date_struct: DateStruct = Field(
+        alias="completionDateStruct",
+        default=DateStruct(),
+        description="The date the final participant was examined or received "
+                    "an intervention for purposes of final collection of data "
+                    "for the primary and secondary outcome measures and "
+                    "adverse events (for example, last participant’s last "
+                    "visit)",
+    )
+    last_update_submit_date: datetime = Field(alias="lastUpdateSubmitDate", default=None)
     overall_status: str = Field(alias="overallStatus", default=None)
     why_stopped: str = Field(alias="whyStopped", default=None)
 


### PR DESCRIPTION
This PR adds new fields to parse from clinicaltrials.gov and updates some of the grounding logic to use the new data.

### New fields:
- Brief summary of trial
- Detailed description of trial
- Official title of trial
- Intervention description
- Date fields:
  - Primary completion date (date when data collection for primary outcome is done)
  - Completion date (date when data collection for primary, secondary outcomes and adverse events)
  - Last updated date (date when the data on clinicaltrials.gov was last updated)

### Updated logic when grounding:
- Use the brief summary and trial description for grounding context
- Try to annotate the intervention description when the intervention name has no grounding or annotations

### Other updates
- Deleted a duplicated class, `Edge`,  in models.py
- Add trial curie to saved bioentity data in order to get correct intervention - label mapping