### PR TITLE
Add missing field name

### DIFF
--- a/src/trialsynth/base/resources/default_config.ini
+++ b/src/trialsynth/base/resources/default_config.ini
@@ -31,7 +31,7 @@ RAW_TRIAL_DATA = clinicaltrials.pkl.gz
 
 API_URL = https://clinicaltrials.gov/api/v2/studies
 
-API_FIELDS = NCTId, BriefTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule, ReferencesModule, DescriptionModule
+API_FIELDS = NCTId, BriefTitle, OfficialTitle, StudyType, DesignInfo, Condition, ConditionMesh, InterventionMesh, Intervention, PrimaryOutcomeMeasure, PrimaryOutcomeTimeFrame, SecondaryOutcomeMeasure, SecondaryOutcomeTimeFrame, SecondaryIdType, SecondaryId, Phase, StatusModule, ReferencesModule, DescriptionModule
 
 PROCESSED_DATA = clinical_trials.tsv.gz
 

--- a/src/trialsynth/clinical_trials_dot_gov/fetch.py
+++ b/src/trialsynth/clinical_trials_dot_gov/fetch.py
@@ -91,7 +91,7 @@ class CTFetcher(Fetcher):
         except requests.exceptions.Timeout:
             if retries > 0:
                 logger.warning(
-                    f'Retrying request to {self.url} with params {self.api_parameters}'
+                    f'Retrying request to {self.url} with params {self.api_parameters} '
                     f'due to timeout. Retries left: {retries - 1}'
                 )
                 sleep(5)  # Wait a bit before retrying


### PR DESCRIPTION
This PR is a follow up to #14. In #14, the logic to handle the `officialTitle` field was added, but the field itself was missing in `default_conig.ini`. That is fixed in this PR.

Other update:
- Fix missing space in comment for clearer warning message.