### PR TITLE
Updates

### DIFF
--- a/.github/workflows/stability_tests.yml
+++ b/.github/workflows/stability_tests.yml
@@ -4,10 +4,12 @@ on:
   push:
     paths:
       - .github/workflows/stability_tests.yml
+      - tests/*
       - src/*
   pull_request:
     paths:
       - .github/workflows/stability_tests.yml
+      - tests/*
       - src/*
   workflow_dispatch:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "bioregistry (~=0.11.6)",
   "click (~=8.1)",
   "gilda (~=1.1)",
-  "indra @ git+https://github.com/sorgerlab/indra.git",
+  "indra @ git+https://github.com/gyorilab/indra.git",
   "numpy (~=1.26)",  # https://github.com/allenai/scispacy/issues/536
   "overrides (~=7.7)",
   "pandas (~=2.2)",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,13 +28,10 @@ dependencies = [
   "click (~=8.1)",
   "gilda (~=1.1)",
   "indra @ git+https://github.com/gyorilab/indra.git",
-  "numpy (~=1.26)",  # https://github.com/allenai/scispacy/issues/536
   "overrides (~=7.7)",
   "pandas (~=2.2)",
   "pydantic[email] (~=2.7)",
   "requests (~=2.31)",
-  "scispacy (~=0.5.5)",
-  "spacy (~=3.7)",  # https://github.com/allenai/scispacy/blob/v0.5.5/setup.py#L44
   "tqdm (~=4.66)",
 ]
 
@@ -42,4 +39,9 @@ dependencies = [
 [dependency-groups]
 test = [
   "pytest (~=8.1)",
+]
+scispacy = [
+  "scispacy (~=0.5.5)",
+  "spacy (~=3.7)",  # https://github.com/allenai/scispacy/blob/v0.5.5/setup.py#L44
+  "numpy (~=1.26)",  # https://github.com/allenai/scispacy/issues/536
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
   "addict (~=2.4)",
-  "bioregistry (~=0.11.6)",
+  "bioregistry (~=0.12.13)",
   "click (~=8.1)",
   "gilda (~=1.1)",
   "indra @ git+https://github.com/gyorilab/indra.git",

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -187,10 +187,9 @@ class Grounder:
     def _yield_entity(
         self, entity: BioEntity, match: ScoredMatch
     ) -> Iterator[BioEntity]:
-        groundings_dict = dict(match.get_groundings())
-        mesh_id = groundings_dict.get(self.mesh_prefix)
-
-        if mesh_id:
+        # Do special handling for MESH entities
+        if match.term.db == self.mesh_prefix:
+            mesh_id = match.term.id
             if self.restrict_mesh_prefix and any(mesh_client.has_tree_prefix(mesh_id, prefix) for prefix in self.restrict_mesh_prefix):
                 yield self._create_grounded_entity(
                     entity, db_ns=self.mesh_prefix, db_id=mesh_id, norm_text=match.term.entry_name

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -27,7 +27,7 @@ GrounderSignature = Callable[
     [str, Optional[str], Optional[list[str]], Optional[list[str]]],
     list[ScoredMatch]
 ]
-AnnotatorSignature = Callable[[str, Optional[str]], list[Annotation]]
+AnnotatorSignature = Optional[Callable[[str, Optional[str]], list[Annotation]]]
 
 
 class Annotator:

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -18,8 +18,6 @@ from .util import (
     must_override
 )
 
-import spacy
-
 logger = logging.getLogger(__name__)
 
 
@@ -76,27 +74,6 @@ class GildaAnnotator(Annotator):
         )
 
 
-class SciSpacyAnnotator(Annotator):
-    def __init__(self, *, model: str, namespaces: Optional[list[str]] = None):
-        super().__init__(namespaces=namespaces)
-        try:
-            self.model = spacy.load(model)
-        except OSError:
-            logger.info("spaCy model not found")
-            raise
-
-    def annotate(self, text: str, *, context: str = None):
-        context_text = context if context is not None else text
-        doc = self.model(text)
-
-        annotations: list[Annotation] = []
-        for entity in doc.ents:
-            matches = gilda.ground(entity.text, namespaces=self.namespaces, context=context_text)
-            if matches:
-                annotations.append(
-                    Annotation(entity.text, matches, entity.start_char, entity.end_char)
-                )
-            return annotations
 
 
 class Grounder:

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -138,12 +138,14 @@ class Grounder:
         *,
         namespaces: Optional[list[str]] = None,
         restrict_mesh_prefix: list[str] = None,
-        annotator: AnnotatorSignature = GildaAnnotator(),
+        annotator: AnnotatorSignature = None,
         grounder_func: Optional[GrounderSignature] = None,
         mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
     ):
         self.namespaces: Optional[list[str]] = namespaces
         self.restrict_mesh_prefix = restrict_mesh_prefix
+        if annotator is None:
+            annotator = GildaAnnotator(namespaces=namespaces, mesh_prefix=mesh_prefix)
         self.annotator = annotator
         if grounder_func is None:
             grounder_func = gilda.ground

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -60,8 +60,20 @@ class Annotator:
 
 
 class GildaAnnotator(Annotator):
+    def __init__(
+        self,
+        *,
+        namespaces: Optional[list[str]] = None,
+        mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
+    ):
+        if namespaces is None:
+            logger.info("No namespaces provided, using default Gilda namespaces.")
+            namespaces = gilda.grounder.DEFAULT_NAMESPACE_PRIORITY
+        super().__init__(namespaces=namespaces, mesh_prefix=mesh_prefix)
     def annotate(self, text: str, *, context: str = None):
-        return gilda.annotate(text=text, context_text=context, namespaces=self.namespaces)
+        return gilda.annotate(
+            text=text, context_text=context, namespaces=self.namespaces
+        )
 
 
 class SciSpacyAnnotator(Annotator):

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -253,7 +253,7 @@ class ConditionGrounder(Grounder):
         namespaces: Optional[list[str]] = None,
         annotator: Optional[AnnotatorSignature] = None,
         grounder_func: Optional[GrounderSignature] = None,
-        mesh_prefix: Optional[Literal["mesh", "MESH"]] = "MESH"
+        mesh_prefix: Literal["mesh", "MESH"] = "MESH"
     ):
         if namespaces is None:
             namespaces = CONDITION_NS

--- a/src/trialsynth/base/resources/scispacy_ground.py
+++ b/src/trialsynth/base/resources/scispacy_ground.py
@@ -1,0 +1,35 @@
+import logging
+import gilda
+from typing import Optional
+from trialsynth.base.ground import Annotator, Annotation
+
+try:
+    import spacy
+except ImportError:
+    raise ImportError("Please install scispacy to use the SciSpacyAnnotator.")
+
+
+logger = logging.getLogger(__name__)
+
+
+class SciSpacyAnnotator(Annotator):
+    def __init__(self, *, model: str, namespaces: Optional[list[str]] = None):
+        super().__init__(namespaces=namespaces)
+        try:
+            self.model = spacy.load(model)
+        except OSError:
+            logger.info("spaCy model not found")
+            raise
+
+    def annotate(self, text: str, *, context: str = None):
+        context_text = context if context is not None else text
+        doc = self.model(text)
+
+        annotations: list[Annotation] = []
+        for entity in doc.ents:
+            matches = gilda.ground(entity.text, namespaces=self.namespaces, context=context_text)
+            if matches:
+                annotations.append(
+                    Annotation(entity.text, matches, entity.start_char, entity.end_char)
+                )
+            return annotations

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -39,7 +39,7 @@ class Transformer:
             trial.source,
             self.transform_phases(trial.phases),
             trial.start_date.year if trial.start_date else "",
-            self.tranform_anticipated_date(trial),
+            self.transform_estimated_date(trial),
             trial.primary_completion_date.year if trial.primary_completion_date else "",
             trial.primary_completion_date_type or "",
             trial.completion_date.year if trial.completion_date else "",
@@ -51,9 +51,11 @@ class Transformer:
         )
 
     @staticmethod
-    def tranform_anticipated_date(trial: Trial) -> str:
+    def transform_estimated_date(trial: Trial) -> str:
+        # See:
+        # https://clinicaltrials.gov/data-api/about-api/study-data-structure#enum-DateType
         if trial.start_date_type is not None:
-            if trial.start_date_type.lower() == "anticipated":
+            if trial.start_date_type.lower() == "estimated":
                 return "true"
             else:
                 return "false"

--- a/uv.lock
+++ b/uv.lock
@@ -558,8 +558,8 @@ wheels = [
 
 [[package]]
 name = "indra"
-version = "1.23.0"
-source = { git = "https://github.com/sorgerlab/indra.git#dd306759c1e51140d3e5373565c9bf525ed85d3f" }
+version = "1.24.0"
+source = { git = "https://github.com/gyorilab/indra.git#b4ae1e73fd304bfc98751b6576607ebe54dbca26" }
 dependencies = [
     { name = "future" },
     { name = "ipython", version = "8.37.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -793,10 +793,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/55/2cb24ea48aa30c99f805921c1c7860c1f45c0e811e44ee4e6a155668de06/lxml-6.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:219e0431ea8006e15005767f0351e3f7f9143e793e58519dc97fe9e07fae5563", size = 4952289, upload-time = "2025-06-28T18:47:25.602Z" },
     { url = "https://files.pythonhosted.org/packages/31/c0/b25d9528df296b9a3306ba21ff982fc5b698c45ab78b94d18c2d6ae71fd9/lxml-6.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:bd5913b4972681ffc9718bc2d4c53cde39ef81415e1671ff93e9aa30b46595e7", size = 5111310, upload-time = "2025-06-28T18:47:28.136Z" },
     { url = "https://files.pythonhosted.org/packages/e9/af/681a8b3e4f668bea6e6514cbcb297beb6de2b641e70f09d3d78655f4f44c/lxml-6.0.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:390240baeb9f415a82eefc2e13285016f9c8b5ad71ec80574ae8fa9605093cd7", size = 5025457, upload-time = "2025-06-26T16:26:15.068Z" },
+    { url = "https://files.pythonhosted.org/packages/99/b6/3a7971aa05b7be7dfebc7ab57262ec527775c2c3c5b2f43675cac0458cad/lxml-6.0.0-cp312-cp312-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d6e200909a119626744dd81bae409fc44134389e03fbf1d68ed2a55a2fb10991", size = 5657016, upload-time = "2025-07-03T19:19:06.008Z" },
     { url = "https://files.pythonhosted.org/packages/69/f8/693b1a10a891197143c0673fcce5b75fc69132afa81a36e4568c12c8faba/lxml-6.0.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ca50bd612438258a91b5b3788c6621c1f05c8c478e7951899f492be42defc0da", size = 5257565, upload-time = "2025-06-26T16:26:17.906Z" },
     { url = "https://files.pythonhosted.org/packages/a8/96/e08ff98f2c6426c98c8964513c5dab8d6eb81dadcd0af6f0c538ada78d33/lxml-6.0.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:c24b8efd9c0f62bad0439283c2c795ef916c5a6b75f03c17799775c7ae3c0c9e", size = 4713390, upload-time = "2025-06-26T16:26:20.292Z" },
     { url = "https://files.pythonhosted.org/packages/a8/83/6184aba6cc94d7413959f6f8f54807dc318fdcd4985c347fe3ea6937f772/lxml-6.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:afd27d8629ae94c5d863e32ab0e1d5590371d296b87dae0a751fb22bf3685741", size = 5066103, upload-time = "2025-06-26T16:26:22.765Z" },
     { url = "https://files.pythonhosted.org/packages/ee/01/8bf1f4035852d0ff2e36a4d9aacdbcc57e93a6cd35a54e05fa984cdf73ab/lxml-6.0.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:54c4855eabd9fc29707d30141be99e5cd1102e7d2258d2892314cf4c110726c3", size = 4791428, upload-time = "2025-06-26T16:26:26.461Z" },
+    { url = "https://files.pythonhosted.org/packages/29/31/c0267d03b16954a85ed6b065116b621d37f559553d9339c7dcc4943a76f1/lxml-6.0.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c907516d49f77f6cd8ead1322198bdfd902003c3c330c77a1c5f3cc32a0e4d16", size = 5678523, upload-time = "2025-07-03T19:19:09.837Z" },
     { url = "https://files.pythonhosted.org/packages/5c/f7/5495829a864bc5f8b0798d2b52a807c89966523140f3d6fa3a58ab6720ea/lxml-6.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:36531f81c8214e293097cd2b7873f178997dae33d3667caaae8bdfb9666b76c0", size = 5281290, upload-time = "2025-06-26T16:26:29.406Z" },
     { url = "https://files.pythonhosted.org/packages/79/56/6b8edb79d9ed294ccc4e881f4db1023af56ba451909b9ce79f2a2cd7c532/lxml-6.0.0-cp312-cp312-win32.whl", hash = "sha256:690b20e3388a7ec98e899fd54c924e50ba6693874aa65ef9cb53de7f7de9d64a", size = 3613495, upload-time = "2025-06-26T16:26:31.588Z" },
     { url = "https://files.pythonhosted.org/packages/0b/1e/cc32034b40ad6af80b6fd9b66301fc0f180f300002e5c3eb5a6110a93317/lxml-6.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:310b719b695b3dd442cdfbbe64936b2f2e231bb91d998e99e6f0daf991a3eba3", size = 4014711, upload-time = "2025-06-26T16:26:33.723Z" },
@@ -807,10 +809,12 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/46/3572761efc1bd45fcafb44a63b3b0feeb5b3f0066886821e94b0254f9253/lxml-6.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d18a25b19ca7307045581b18b3ec9ead2b1db5ccd8719c291f0cd0a5cec6cb81", size = 4947559, upload-time = "2025-06-28T18:47:31.091Z" },
     { url = "https://files.pythonhosted.org/packages/94/8a/5e40de920e67c4f2eef9151097deb9b52d86c95762d8ee238134aff2125d/lxml-6.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d4f0c66df4386b75d2ab1e20a489f30dc7fd9a06a896d64980541506086be1f1", size = 5102143, upload-time = "2025-06-28T18:47:33.612Z" },
     { url = "https://files.pythonhosted.org/packages/7c/4b/20555bdd75d57945bdabfbc45fdb1a36a1a0ff9eae4653e951b2b79c9209/lxml-6.0.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9f4b481b6cc3a897adb4279216695150bbe7a44c03daba3c894f49d2037e0a24", size = 5021931, upload-time = "2025-06-26T16:26:47.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/cf03b412f3763d4ca23b25e70c96a74cfece64cec3addf1c4ec639586b13/lxml-6.0.0-cp313-cp313-manylinux_2_27_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:8a78d6c9168f5bcb20971bf3329c2b83078611fbe1f807baadc64afc70523b3a", size = 5645469, upload-time = "2025-07-03T19:19:13.32Z" },
     { url = "https://files.pythonhosted.org/packages/d4/dd/39c8507c16db6031f8c1ddf70ed95dbb0a6d466a40002a3522c128aba472/lxml-6.0.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae06fbab4f1bb7db4f7c8ca9897dc8db4447d1a2b9bee78474ad403437bcc29", size = 5247467, upload-time = "2025-06-26T16:26:49.998Z" },
     { url = "https://files.pythonhosted.org/packages/4d/56/732d49def0631ad633844cfb2664563c830173a98d5efd9b172e89a4800d/lxml-6.0.0-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:1fa377b827ca2023244a06554c6e7dc6828a10aaf74ca41965c5d8a4925aebb4", size = 4720601, upload-time = "2025-06-26T16:26:52.564Z" },
     { url = "https://files.pythonhosted.org/packages/8f/7f/6b956fab95fa73462bca25d1ea7fc8274ddf68fb8e60b78d56c03b65278e/lxml-6.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1676b56d48048a62ef77a250428d1f31f610763636e0784ba67a9740823988ca", size = 5060227, upload-time = "2025-06-26T16:26:55.054Z" },
     { url = "https://files.pythonhosted.org/packages/97/06/e851ac2924447e8b15a294855caf3d543424364a143c001014d22c8ca94c/lxml-6.0.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:0e32698462aacc5c1cf6bdfebc9c781821b7e74c79f13e5ffc8bfe27c42b1abf", size = 4790637, upload-time = "2025-06-26T16:26:57.384Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d4/fd216f3cd6625022c25b336c7570d11f4a43adbaf0a56106d3d496f727a7/lxml-6.0.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4d6036c3a296707357efb375cfc24bb64cd955b9ec731abf11ebb1e40063949f", size = 5662049, upload-time = "2025-07-03T19:19:16.409Z" },
     { url = "https://files.pythonhosted.org/packages/52/03/0e764ce00b95e008d76b99d432f1807f3574fb2945b496a17807a1645dbd/lxml-6.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:7488a43033c958637b1a08cddc9188eb06d3ad36582cebc7d4815980b47e27ef", size = 5272430, upload-time = "2025-06-26T16:27:00.031Z" },
     { url = "https://files.pythonhosted.org/packages/5f/01/d48cc141bc47bc1644d20fe97bbd5e8afb30415ec94f146f2f76d0d9d098/lxml-6.0.0-cp313-cp313-win32.whl", hash = "sha256:5fcd7d3b1d8ecb91445bd71b9c88bdbeae528fefee4f379895becfc72298d181", size = 3612896, upload-time = "2025-06-26T16:27:04.251Z" },
     { url = "https://files.pythonhosted.org/packages/f4/87/6456b9541d186ee7d4cb53bf1b9a0d7f3b1068532676940fdd594ac90865/lxml-6.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:2f34687222b78fff795feeb799a7d44eca2477c3d9d3a46ce17d51a4f383e32e", size = 4013132, upload-time = "2025-06-26T16:27:06.415Z" },
@@ -2341,17 +2345,19 @@ dependencies = [
     { name = "click" },
     { name = "gilda" },
     { name = "indra" },
-    { name = "numpy" },
     { name = "overrides" },
     { name = "pandas" },
     { name = "pydantic", extra = ["email"] },
     { name = "requests" },
-    { name = "scispacy" },
-    { name = "spacy" },
     { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
+scispacy = [
+    { name = "numpy" },
+    { name = "scispacy" },
+    { name = "spacy" },
+]
 test = [
     { name = "pytest" },
 ]
@@ -2362,18 +2368,20 @@ requires-dist = [
     { name = "bioregistry", specifier = "~=0.11.6" },
     { name = "click", specifier = "~=8.1" },
     { name = "gilda", specifier = "~=1.1" },
-    { name = "indra", git = "https://github.com/sorgerlab/indra.git" },
-    { name = "numpy", specifier = "~=1.26" },
+    { name = "indra", git = "https://github.com/gyorilab/indra.git" },
     { name = "overrides", specifier = "~=7.7" },
     { name = "pandas", specifier = "~=2.2" },
     { name = "pydantic", extras = ["email"], specifier = "~=2.7" },
     { name = "requests", specifier = "~=2.31" },
-    { name = "scispacy", specifier = "~=0.5.5" },
-    { name = "spacy", specifier = "~=3.7" },
     { name = "tqdm", specifier = "~=4.66" },
 ]
 
 [package.metadata.requires-dev]
+scispacy = [
+    { name = "numpy", specifier = "~=1.26" },
+    { name = "scispacy", specifier = "~=0.5.5" },
+    { name = "spacy", specifier = "~=3.7" },
+]
 test = [{ name = "pytest", specifier = "~=8.1" }]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -76,20 +76,20 @@ wheels = [
 
 [[package]]
 name = "bioregistry"
-version = "0.11.35"
+version = "0.12.39"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "curies" },
     { name = "more-click" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pystow" },
     { name = "requests" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/f2/f1e162bda13c762fa8ac2b20139af61181cf8c0aee70fb1ebf380f280829/bioregistry-0.11.35.tar.gz", hash = "sha256:f3c57638c193161674f3569312dd6c3a3f99ace862a5c8e0c7986c06e30815d0", size = 6119956, upload-time = "2025-01-28T09:40:56.726Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/87/cc29537841df02603631a7abb9d8776d08ff33b958485a7e7aa41d5fee29/bioregistry-0.12.39.tar.gz", hash = "sha256:c9b9a80a6799e2535b5d4f55b891f6f1ffee1a1e5fd92cd85f03c0d678dade81", size = 6372981, upload-time = "2025-09-13T02:28:37.577Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/ab/8441327ba6f941519b33209736783e9b733f2532dbdfcdaa7feee828b910/bioregistry-0.11.35-py3-none-any.whl", hash = "sha256:64713a6595190175d506f2053b1599707a8cf266a2ba44cff3c2e29b71063f90", size = 5303598, upload-time = "2025-01-28T09:40:49.538Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ac/3edf6413e4ad2d4972e4298388fb3cd6461b976832154f94a911d4ecebbe/bioregistry-0.12.39-py3-none-any.whl", hash = "sha256:0647bac117672dee9719ff68002ffd5ce37950ed42ed24917a6229f0d3a59f7b", size = 5562191, upload-time = "2025-09-13T02:28:34.397Z" },
 ]
 
 [[package]]
@@ -1566,7 +1566,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/6d/f5/59f3375b12172651c
 
 [[package]]
 name = "pystow"
-version = "0.7.1"
+version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1574,9 +1574,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1d/40/cec250d2bde19dfc935bad48db07687056defdb4da5f753c70d5ea3bdb7c/pystow-0.7.1.tar.gz", hash = "sha256:ad0605f378b1b9ea0e57feb0f198df25717ee9d29596a643a8d00492e21cd62a", size = 36443, upload-time = "2025-06-23T11:33:10.347Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/f2/02211684655aa52b10d95376ef63b4f09638fa28acbbf7c2d1f49e0c9ddb/pystow-0.7.8.tar.gz", hash = "sha256:f19c861537f041a91c21ffeed007802a5ced43c133705f473b450c866218a3d6", size = 40078, upload-time = "2025-08-27T13:34:08.701Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/08/cb/9799961c56349b7439d24627545eeb091423594722405881babd0824326e/pystow-0.7.1-py3-none-any.whl", hash = "sha256:ea5b08f670a9126e368f719b29c02414a7480c13c30efec03d5cdfa69fb929f6", size = 39386, upload-time = "2025-06-23T11:33:07.418Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fb/e2027b4d1093ac980a26aa81023582e61604648932d0cd634a6ca96ac3bb/pystow-0.7.8-py3-none-any.whl", hash = "sha256:2524bc2377afb08590e2417571adb9507de55b6d60b628b4c02ff69a9b8dfba8", size = 43282, upload-time = "2025-08-27T13:34:07.504Z" },
 ]
 
 [[package]]
@@ -2365,7 +2365,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "addict", specifier = "~=2.4" },
-    { name = "bioregistry", specifier = "~=0.11.6" },
+    { name = "bioregistry", specifier = "~=0.12.13" },
     { name = "click", specifier = "~=8.1" },
     { name = "gilda", specifier = "~=1.1" },
     { name = "indra", git = "https://github.com/gyorilab/indra.git" },


### PR DESCRIPTION
This PR does the following updates:
- The default GildaAnnotator now uses the namespace priority within gilda as default namespace if none is provided
- Only do mesh handling in `Grounder._yield_entity` when mesh is the prioritized namespace for the grounding match
- Update a transformer function