### PR TITLE
ash/trial-result-extraction: Replace PMC download with S3 text extraction

### DIFF
--- a/src/trialsynth/base/extract/build_pubmed_nct_links.py
+++ b/src/trialsynth/base/extract/build_pubmed_nct_links.py
@@ -1,0 +1,152 @@
+"""
+Extract PMID -> NCT ID links from the PubMed XML baseline archive.
+
+NCT IDs are sourced from:
+  - DataBank blocks where DataBankName = "ClinicalTrials.gov"
+  - AbstractText free-text mentions (regex NCT\d{8})
+
+Output: pubmed_nct_links.csv saved to trialsynth/clinicaltrials/ via pystow.
+Checkpoint: processed_files.txt in the same directory for safe resume.
+
+Usage:
+    python build_pubmed_nct_links.py --archive /path/to/xml_archive.tar
+    python build_pubmed_nct_links.py --archive /path/to/xml_archive.tar --threads 8
+    python build_pubmed_nct_links.py --archive /path/to/xml_archive.tar --limit 10
+"""
+
+import argparse
+import csv
+import gzip
+import io
+import logging
+import re
+import tarfile
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import pystow
+import tqdm
+
+logger = logging.getLogger('trialsynth.base.extract.build_pubmed_nct_links')
+
+PMID_RE = re.compile(r'<PMID[^>]*>(\d+)</PMID>')
+DATABANK_BLOCK_RE = re.compile(r'<DataBank>(.*?)</DataBank>', re.DOTALL)
+DATABANK_NAME_RE = re.compile(r'<DataBankName>ClinicalTrials\.gov</DataBankName>')
+ACCESSION_RE = re.compile(r'<AccessionNumber>(NCT\d{8})</AccessionNumber>')
+ABSTRACT_RE = re.compile(r'<AbstractText[^>]*>(.*?)</AbstractText>', re.DOTALL)
+NCT_RE = re.compile(r'NCT\d{8}')
+
+TOTAL_FILES = 1613  # number of .xml.gz files in the PubMed 2025 baseline archive
+
+
+def parse_member(data: bytes) -> list[tuple[str, str]]:
+    """Parse a gzipped PubMed XML file via regex and return (pmid, nct_id) pairs."""
+    with gzip.open(io.BytesIO(data)) as gz:
+        text = gz.read().decode('utf-8', errors='replace')
+
+    rows = []
+    for article in text.split('<PubmedArticle>')[1:]:
+        pmid_match = PMID_RE.search(article)
+        if not pmid_match:
+            continue
+        pmid = pmid_match.group(1)
+
+        nct_ids = set()
+
+        # Structured: DataBank blocks for ClinicalTrials.gov
+        for block in DATABANK_BLOCK_RE.finditer(article):
+            block_text = block.group(1)
+            if DATABANK_NAME_RE.search(block_text):
+                for acc in ACCESSION_RE.finditer(block_text):
+                    nct_ids.add(acc.group(1))
+
+        # Free-text: regex over AbstractText only
+        for abstract in ABSTRACT_RE.finditer(article):
+            nct_ids.update(NCT_RE.findall(abstract.group(1)))
+
+        for nct_id in nct_ids:
+            rows.append((pmid, nct_id))
+
+    return rows
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--archive', type=Path, required=True,
+                        help='Path to xml_archive.tar')
+    parser.add_argument('--threads', type=int, default=8,
+                        help='Number of worker threads (default: 8)')
+    parser.add_argument('--limit', type=int, default=None,
+                        help='Process only first N files (for testing)')
+    args = parser.parse_args()
+
+    output_path = pystow.join("trialsynth", "clinicaltrials", name="pubmed_nct_links.csv")
+    checkpoint_path = pystow.join("trialsynth", "clinicaltrials", name="processed_files.txt")
+
+    done = set()
+    if checkpoint_path.exists():
+        done = set(checkpoint_path.read_text(encoding='utf-8').splitlines())
+        logger.info(f"Resuming: {len(done)} files already processed.")
+
+    csv_exists = output_path.exists()
+    total = (args.limit or TOTAL_FILES) - len(done)
+    logger.info(f"~{total} files to process, {len(done)} skipped.")
+
+    write_lock = threading.Lock()
+    total_links = 0
+
+    sem = threading.Semaphore(args.threads * 2)
+
+    with open(output_path, 'a', newline='', encoding='utf-8') as csv_file, \
+         open(checkpoint_path, 'a', encoding='utf-8') as ckpt_file, \
+         tqdm.tqdm(total=total, desc='Parsing', unit='file') as pbar:
+
+        writer = csv.writer(csv_file)
+        if not csv_exists:
+            writer.writerow(['pmid', 'nct_id'])
+
+        def process(name: str, data: bytes) -> None:
+            try:
+                rows = parse_member(data)
+                with write_lock:
+                    writer.writerows(rows)
+                    csv_file.flush()
+                    ckpt_file.write(name + '\n')
+                    ckpt_file.flush()
+                    nonlocal total_links
+                    total_links += len(rows)
+                    pbar.update(1)
+                    pbar.set_postfix(links=total_links)
+                    logger.info(f"[{pbar.n}/{total}] {name} -> {len(rows)} links")
+            except Exception as e:
+                logger.error(f"Failed {name}: {e}")
+            finally:
+                sem.release()
+
+        processed = 0
+        with tarfile.open(args.archive, 'r:') as tar, \
+             ThreadPoolExecutor(max_workers=args.threads) as executor:
+
+            for member in tar:
+                if not member.name.endswith('.xml.gz'):
+                    continue
+                if member.name in done:
+                    continue
+                if args.limit and processed >= args.limit:
+                    break
+
+                sem.acquire()
+                data = tar.extractfile(member).read()
+                executor.submit(process, member.name, data)
+                processed += 1
+
+    logger.info(f"Done. {total_links} links written to {output_path}.")
+
+
+if __name__ == '__main__':
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s - %(levelname)s - %(message)s'
+    )
+    main()

--- a/src/trialsynth/base/extract/build_pubmed_nct_links.py
+++ b/src/trialsynth/base/extract/build_pubmed_nct_links.py
@@ -1,4 +1,6 @@
 """
+Retained for historical record; not part of the active trialsynth pipeline.
+
 Extract PMID -> NCT ID links from the PubMed XML baseline archive.
 
 NCT IDs are sourced from:

--- a/src/trialsynth/base/extract/extract.py
+++ b/src/trialsynth/base/extract/extract.py
@@ -358,13 +358,13 @@ def main():
 
     content_dir = pystow.module("trialsynth", "content", "txt").base
     output_dir = Path(args.output_dir) if args.output_dir else \
-        pystow.module("indra", "cogex", "clinical_trial_results", "raw").base
+        pystow.join("trialsynth", "results", "raw")
     output_dir.mkdir(parents=True, exist_ok=True)
 
     if args.pmids:
         target_pmids = args.pmids
     else:
-        grounded_dir = pystow.module("indra", "cogex", "clinical_trial_results", "grounded").base
+        grounded_dir = pystow.join("trialsynth", "results", "grounded")
         target_pmids = [f.stem for f in sorted(grounded_dir.glob("*.json"))][:10]
 
     logger.info(f"Running anchor extraction on {len(target_pmids)} PMIDs...")
@@ -389,8 +389,7 @@ def main():
     logger.info(f"{'AVG/paper':<15} {total_in // max(1, len(completed)):>15} {total_out // max(1, len(completed)):>15}")
     logger.info("=" * 60)
 
-    csv_path = pystow.join("indra", "cogex", "clinical_trial_results",
-                           name="token_comparison_anchor.csv")
+    csv_path = pystow.join("trialsynth", "results", name="token_comparison_anchor.csv")
     with open(csv_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=["pmid", "status", "input_tokens", "output_tokens"])
         writer.writeheader()

--- a/src/trialsynth/base/extract/generate_html.py
+++ b/src/trialsynth/base/extract/generate_html.py
@@ -158,8 +158,9 @@ def build_evidence_hover(item):
 
 def render_metric_row(name, value_text, item):
     evidence_hover = build_evidence_hover(item)
+    grounding = format_grounding(item.get("grounding")) if isinstance(item, dict) else ""
     return (
-        f"<tr><td>{html.escape(str(name))}{evidence_hover}</td>"
+        f"<tr><td>{html.escape(str(name))}{evidence_hover} {grounding}</td>"
         f"<td style='text-align:right; font-weight:600;'>{html.escape(str(value_text))}</td></tr>"
     )
 

--- a/src/trialsynth/base/extract/ground_results.py
+++ b/src/trialsynth/base/extract/ground_results.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional
 import gilda
 import pystow
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('trialsynth.base.extract.ground_results')
 
 
 def get_gilda_grounding(text: str, sources: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
@@ -163,9 +163,9 @@ def ground_json(input_path: Path, output_path: Path) -> None:
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--input-dir", type=Path,
-                        default=pystow.module("indra", "cogex", "clinical_trial_results", "raw").base)
+                        default=pystow.join("trialsynth", "results", "raw"))
     parser.add_argument("--output-dir", type=Path,
-                        default=pystow.module("indra", "cogex", "clinical_trial_results", "grounded").base)
+                        default=pystow.join("trialsynth", "results", "grounded"))
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
@@ -183,5 +183,4 @@ def main():
 
 
 if __name__ == "__main__":
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
     main()

--- a/src/trialsynth/base/extract/ground_results.py
+++ b/src/trialsynth/base/extract/ground_results.py
@@ -2,15 +2,17 @@
 Ground genetic markers and clinical criteria in extracted JSON files using local Gilda.
 
 Reads raw anchor JSONs and writes grounded versions with HGNC groundings for
-genetic markers and MESH/DOID/EFO groundings for inclusion/exclusion criteria.
+genetic markers and HP/DOID/MESH/EFO groundings for inclusion/exclusion criteria and adverse events.
 
 Usage:
     python ground_results.py --input-dir <raw_dir> --output-dir <grounded_dir>
 """
 
 import argparse
+import csv
 import json
 import logging
+import random
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -19,7 +21,8 @@ import gilda
 import pystow
 
 logger = logging.getLogger('trialsynth.base.extract.ground_results')
-
+AE_NAMESPACES = ["HP", "DOID", "MESH", "EFO"]
+AE_SHORT_TOKEN_MIN_LEN_DEFAULT = 4
 
 def get_gilda_grounding(text: str, sources: Optional[List[str]] = None) -> Optional[Dict[str, Any]]:
     """Ground text using local Gilda library (replaces REST API call)."""
@@ -117,7 +120,35 @@ def ground_marker(item: Any) -> Dict[str, Any]:
     }
 
 
-def ground_json(input_path: Path, output_path: Path) -> None:
+def _normalize_ae_text(text: str) -> str:
+    return re.sub(r"\s+", " ", (text or "").strip())
+
+
+def ground_adverse_event(
+    event_name: str,
+    *,
+    min_len: int,
+) -> Optional[Dict[str, Any]]:
+    clean = _normalize_ae_text(event_name)
+    if len(clean) < min_len:
+        return None
+    top = get_gilda_grounding(clean, sources=AE_NAMESPACES)
+    if not top:
+        return None
+    return {
+        "db": top["db"],
+        "id": top["id"],
+        "name": top["entry_name"],
+        "score": top["score"],
+    }
+
+
+def ground_json(
+    input_path: Path,
+    output_path: Path,
+    *,
+    ae_min_len: int,
+) -> tuple[int, int, list[dict[str, Any]]]:
     with open(input_path, 'r', encoding='utf-8') as f:
         data = json.load(f)
 
@@ -133,31 +164,57 @@ def ground_json(input_path: Path, output_path: Path) -> None:
     data['genetic']['grounded_inclusion'] = grounded_genetic
 
     grounded_inclusion = []
-    for item in data.get('inclusion_criteria', [])[:5]:
+    for item in data.get('inclusion_criteria', []):
         if isinstance(item, str):
             text = item
             ev = "Retrospective migration"
         else:
             text = item.get("text", "")
             ev = item.get("evidence_text", "Retrospective migration")
-        match = get_gilda_grounding(text, sources=["MESH", "DOID", "EFO"])
+        match = get_gilda_grounding(text, sources=["HP", "DOID", "MESH", "EFO"])
         grounded_inclusion.append({"text": text, "evidence_text": ev, "grounding": match})
     data['grounded_inclusion_criteria'] = grounded_inclusion
 
     grounded_exclusion = []
-    for item in data.get('exclusion_criteria', [])[:5]:
+    for item in data.get('exclusion_criteria', []):
         if isinstance(item, str):
             text = item
             ev = "Retrospective migration"
         else:
             text = item.get("text", "")
             ev = item.get("evidence_text", "Retrospective migration")
-        match = get_gilda_grounding(text, sources=["MESH", "DOID", "EFO"])
+        match = get_gilda_grounding(text, sources=["HP", "DOID", "MESH", "EFO"])
         grounded_exclusion.append({"text": text, "evidence_text": ev, "grounding": match})
     data['grounded_exclusion_criteria'] = grounded_exclusion
+    ae_total = 0
+    ae_grounded = 0
+    ae_review_rows: list[dict[str, Any]] = []
+    for arm in data.get("arms", []):
+        arm_name = arm.get("arm_name", "")
+        for ae in arm.get("adverse_events", []):
+            ae_total += 1
+            event_name = ae.get("event_name", "")
+            grounding = ground_adverse_event(
+                event_name,
+                min_len=ae_min_len,
+            )
+            ae["grounding"] = grounding
+            if grounding:
+                ae_grounded += 1
+            ae_review_rows.append({
+                "pmid": str(data.get("pmid", input_path.stem)),
+                "arm_name": arm_name,
+                "event_name": event_name,
+                "grounded_db": (grounding or {}).get("db", ""),
+                "grounded_id": (grounding or {}).get("id", ""),
+                "grounded_name": (grounding or {}).get("name", ""),
+                "score": (grounding or {}).get("score", ""),
+                "evidence_text": ae.get("source_sentence", ""),
+            })
 
     with open(output_path, 'w', encoding='utf-8') as f:
         json.dump(data, f, indent=2)
+    return ae_total, ae_grounded, ae_review_rows
 
 
 def main():
@@ -166,19 +223,89 @@ def main():
                         default=pystow.join("trialsynth", "results", "raw"))
     parser.add_argument("--output-dir", type=Path,
                         default=pystow.join("trialsynth", "results", "grounded"))
+    parser.add_argument("--pmid-list", type=Path, default=None,
+                        help="Optional file with one PMID per line for pilot/smoke subsets.")
+    parser.add_argument("--max-files", type=int, default=None,
+                        help="Optional max number of JSON files to process.")
+    parser.add_argument("--seed", type=int, default=42,
+                        help="Random seed used when sampling --max-files without --pmid-list.")
+    parser.add_argument("--ae-min-len", type=int, default=AE_SHORT_TOKEN_MIN_LEN_DEFAULT)
+    parser.add_argument("--ae-review-csv", type=Path, default=None,
+                        help="Optional CSV path for AE grounding review table.")
+    parser.add_argument("--metrics-json", type=Path, default=None,
+                        help="Optional JSON path for pilot/smoke AE grounding metrics.")
     args = parser.parse_args()
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
     json_files = list(args.input_dir.glob("*.json"))
+    if args.pmid_list:
+        pmids = {
+            line.strip() for line in args.pmid_list.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        }
+        json_files = [p for p in json_files if p.stem in pmids]
+    elif args.max_files and len(json_files) > args.max_files:
+        random.seed(args.seed)
+        json_files = random.sample(json_files, args.max_files)
+    elif args.max_files:
+        json_files = json_files[:args.max_files]
+
     logger.info(f"Grounding {len(json_files)} files...")
+    ae_total = 0
+    ae_grounded = 0
+    ae_rows: list[dict[str, Any]] = []
     for i, jf in enumerate(json_files):
         out = args.output_dir / jf.name
         if out.exists():
             continue
-        ground_json(jf, out)
+        file_total, file_grounded, file_rows = ground_json(
+            jf,
+            out,
+            ae_min_len=args.ae_min_len,
+        )
+        ae_total += file_total
+        ae_grounded += file_grounded
+        ae_rows.extend(file_rows)
         if (i + 1) % 50 == 0:
             logger.info(f"  {i + 1}/{len(json_files)} done")
+    if args.ae_review_csv:
+        args.ae_review_csv.parent.mkdir(parents=True, exist_ok=True)
+        with args.ae_review_csv.open("w", encoding="utf-8", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=[
+                "pmid", "arm_name", "event_name", "grounded_db", "grounded_id",
+                "grounded_name", "score", "evidence_text",
+            ])
+            writer.writeheader()
+            writer.writerows(ae_rows)
+    if args.metrics_json:
+        args.metrics_json.parent.mkdir(parents=True, exist_ok=True)
+        grounded_rows = [r for r in ae_rows if r["grounded_id"]]
+        namespace_counts: Dict[str, int] = {}
+        empty_event_name = 0
+        duplicate_groundings = 0
+        seen = set()
+        for row in ae_rows:
+            if not _normalize_ae_text(row["event_name"]):
+                empty_event_name += 1
+            key = (row["pmid"], row["arm_name"], row["event_name"], row["grounded_db"], row["grounded_id"])
+            if row["grounded_id"] and key in seen:
+                duplicate_groundings += 1
+            seen.add(key)
+        for row in grounded_rows:
+            namespace_counts[row["grounded_db"]] = namespace_counts.get(row["grounded_db"], 0) + 1
+        metrics = {
+            "files_processed": len(json_files),
+            "ae_total": ae_total,
+            "ae_grounded": ae_grounded,
+            "ae_coverage": (ae_grounded / ae_total) if ae_total else 0.0,
+            "namespace_distribution": namespace_counts,
+            "empty_event_name_rate": (empty_event_name / ae_total) if ae_total else 0.0,
+            "duplicate_grounding_rate": (duplicate_groundings / ae_total) if ae_total else 0.0,
+            "ae_min_len": args.ae_min_len,
+            "ae_namespaces": AE_NAMESPACES,
+        }
+        args.metrics_json.write_text(json.dumps(metrics, indent=2), encoding="utf-8")
     logger.info("Done.")
 
 

--- a/src/trialsynth/base/extract/orchestrate.py
+++ b/src/trialsynth/base/extract/orchestrate.py
@@ -116,7 +116,7 @@ def run_extraction(pmids: list[str]):
     stats = []
 
     for pmid in pmids:
-        row = process_pmid(pmid, client, txt_archive, output_dir)
+        row = process_pmid(pmid, client, txt_archive.base, output_dir.base)
         stats.append(row)
         if row["status"] == "ok":
             logger.info(f"  {pmid} extracted ({row['output_tokens']} output tokens)")

--- a/src/trialsynth/base/extract/orchestrate.py
+++ b/src/trialsynth/base/extract/orchestrate.py
@@ -1,13 +1,14 @@
 """
-Orchestrator: intersection PMIDs -> text download -> anchor extraction -> grounded JSONs.
+Orchestrator: intersection PMIDs -> text download -> anchor extraction ->
+grounded JSONs.
 
 Usage:
     python orchestrate.py           # default: 1000 PMIDs
     python orchestrate.py --limit 500
 
 Two-stage checkpointing:
-  - Text download: skipped if <pmid>.txt already exists in txt_archive
-  - Extraction:    skipped if <pmid>.json already exists in output_dir
+- Text download: skipped if <pmid>.txt already exists in txt_archive
+- Extraction:    skipped if <pmid>.json already exists in output_dir
 
 Re-running safely resumes from wherever it left off.
 """
@@ -15,35 +16,34 @@ Re-running safely resumes from wherever it left off.
 import csv
 import gzip
 import logging
-import os
 import pickle
-import shutil
-import tarfile
 import argparse
 from collections import Counter
-from pathlib import Path
 
 import tqdm
 import pystow
-import requests
 from openai import OpenAI
-from pypdf import PdfReader
-from indra.literature.pubmed_client import get_pmid_to_package_url_mapping, get_abstract
+from indra.literature.pmc_client import id_lookup
+from indra.literature.pubmed_client import get_abstract
 
 from trialsynth.base.extract.extract import process_pmid
+from trialsynth.base.extract.pmc_s3 import get_text_s3
 
 output_dir = pystow.module("trialsynth", "results", "raw")
 txt_archive = pystow.module("trialsynth", "content", "txt")
-pdf_archive = pystow.module("trialsynth", "content", "pdfs")
-temp_work = pystow.module("trialsynth", "content", "temp")
-trial_pkl_path = pystow.join("trialsynth", "clinicaltrials", name="clinicaltrials.pkl.gz")
-pubmed_nct_links_path = pystow.join("trialsynth", "clinicaltrials", name="pubmed_nct_links.csv")
+trial_pkl_path = pystow.join(
+    "trialsynth", "clinicaltrials", name="clinicaltrials.pkl.gz"
+)
+pubmed_nct_links_path = pystow.join(
+    "trialsynth", "clinicaltrials", name="pubmed_nct_links.csv"
+)
 
 logger = logging.getLogger('trialsynth.base.extract.orchestrate')
 
 
 def get_intersection_pmids(limit: int = None) -> list[str]:
-    """Return intersection PMIDs (registry RESULT links intersect PubMed scan), up to `limit`."""
+    """Return intersection PMIDs (registry RESULT links intersect PubMed scan),
+    up to `limit`."""
 
     logger.info("Loading registry result links...")
     registry_result_links = set()
@@ -53,7 +53,11 @@ def get_intersection_pmids(limit: int = None) -> list[str]:
         if trial.references:
             for ref in trial.references:
                 pmid = ref[0] if isinstance(ref, (tuple, list)) else ref
-                ref_type = str(ref[1]).upper() if isinstance(ref, (tuple, list)) and len(ref) > 1 else ""
+                ref_type = (
+                    str(ref[1]).upper()
+                    if isinstance(ref, (tuple, list)) and len(ref) > 1
+                    else ""
+                )
                 if pmid and "RESULT" in ref_type:
                     registry_result_links.add(pmid)
 
@@ -74,74 +78,36 @@ def get_intersection_pmids(limit: int = None) -> list[str]:
     return intersection
 
 
-def download_file(url: str, dest: Path) -> bool:
-    try:
-        with requests.get(url, stream=True, timeout=60) as r:
-            r.raise_for_status()
-            with open(dest, "wb") as f:
-                for chunk in r.iter_content(chunk_size=8192):
-                    f.write(chunk)
-        return True
-    except Exception:
-        return False
-
-
 def download_texts(pmids: list[str]):
     logger.info(f"Downloading text for {len(pmids)} PMIDs...")
-    mappings = get_pmid_to_package_url_mapping()
 
     for pmid in tqdm.tqdm(pmids):
         if txt_archive.join(name=f"{pmid}.txt").exists():
             continue
 
-        for item in temp_work.glob("*"):
-            if item.is_file():
-                os.remove(item)
-            elif item.is_dir():
-                shutil.rmtree(item)
-
         try:
-            localized = False
+            text = None
             source = ""
-            package_url = mappings.get(pmid)
 
-            if package_url:
-                pkg_path = temp_work.join(name=f"temp_{pmid}.tar.gz")
-                if download_file(package_url, pkg_path):
-                    extract_path = temp_work.join(f"extract_{pmid}")
-                    try:
-                        with tarfile.open(pkg_path, "r:gz") as tar:
-                            tar.extractall(path=extract_path)
-                        pdfs = list(extract_path.rglob("*.pdf"))
-                        if pdfs:
-                            shutil.move(str(pdfs[0]), temp_work.join(name=f"{pmid}.pdf").as_posix())
-                            localized = True
-                            source = "PMC"
-                    except Exception:
-                        pass
+            pmcid = id_lookup(pmid, idtype="pmid").get("pmcid")
+            if pmcid:
+                text = get_text_s3(pmcid)
+                if text:
+                    source = f"PMC-S3:{pmcid}"
 
-            if not localized:
-                abstract = get_abstract(pmid, prepend_title=True)
-                if abstract:
-                    with open(txt_archive.join(name=f"{pmid}.txt"), "w", encoding="utf-8") as f:
-                        f.write(abstract)
-                    localized = True
+            if not text:
+                text = get_abstract(pmid, prepend_title=True)
+                if text:
                     source = "ABS"
 
-            if localized:
-                if source == "PMC":
-                    pdf_file = temp_work.join(name=f"{pmid}.pdf")
-                    reader = PdfReader(pdf_file)
-                    text = "\n".join(page.extract_text() for page in reader.pages)
-                    txt_archive.join(name=f"{pmid}.txt").write_text(text, encoding="utf-8")
-                    shutil.move(pdf_file.as_posix(),
-                                pdf_archive.join(name=pdf_file.name).as_posix())
+            if text:
+                txt_archive.join(name=f"{pmid}.txt").write_text(text, encoding="utf-8")
                 logger.info(f"{pmid} ({source}) - OK")
             else:
                 logger.info(f"{pmid} - NO CONTENT")
 
         except Exception as e:
-            logger.info(f"[{pmid} - FAILED: {e}")
+            logger.info(f"{pmid} - FAILED: {e}")
 
 
 def run_extraction(pmids: list[str]):
@@ -161,16 +127,22 @@ def run_extraction(pmids: list[str]):
 
     statuses = Counter(r["status"] for r in stats)
 
-    logger.info(f"Extraction complete: {statuses['ok']} new, {statuses['skipped']} "
-                f"skipped, {statuses['missing_text']} missing text, "
-                f"{len(statuses) - statuses['ok'] - statuses['skipped'] - statuses['missing_text']} errors")
+    n_errors = (
+        len(statuses) - statuses['ok'] - statuses['skipped'] - statuses['missing_text']
+    )
+    logger.info(
+        f"Extraction complete: {statuses['ok']} new, {statuses['skipped']} skipped, "
+        f"{statuses['missing_text']} missing text, {n_errors} errors"
+    )
     if statuses.get('completed'):
         total_out = sum(r["output_tokens"] for r in stats if r["status"] == "completed")
         logger.info(f"Avg output tokens/paper: {total_out // statuses['completed']}")
 
     csv_path = pystow.join("trialsynth", "results", name="extraction_stats.csv")
     with open(csv_path, "w", newline="") as f:
-        writer = csv.DictWriter(f, fieldnames=["pmid", "status", "input_tokens", "output_tokens"])
+        writer = csv.DictWriter(
+            f, fieldnames=["pmid", "status", "input_tokens", "output_tokens"]
+        )
         writer.writeheader()
         writer.writerows(stats)
     logger.info(f"Stats saved to {csv_path}")

--- a/src/trialsynth/base/extract/orchestrate.py
+++ b/src/trialsynth/base/extract/orchestrate.py
@@ -32,10 +32,10 @@ from indra.literature.pubmed_client import get_pmid_to_package_url_mapping, get_
 
 from trialsynth.base.extract.extract import process_pmid
 
-output_dir  = pystow.module("trialsynth", "results", "raw")
+output_dir = pystow.module("trialsynth", "results", "raw")
 txt_archive = pystow.module("trialsynth", "content", "txt")
 pdf_archive = pystow.module("trialsynth", "content", "pdfs")
-temp_work   = pystow.module("trialsynth", "content", "temp")
+temp_work = pystow.module("trialsynth", "content", "temp")
 trial_pkl_path = pystow.join("trialsynth", "clinicaltrials", name="clinicaltrials.pkl.gz")
 pubmed_nct_links_path = pystow.join("trialsynth", "clinicaltrials", name="pubmed_nct_links.csv")
 
@@ -47,7 +47,7 @@ def get_intersection_pmids(limit: int = None) -> list[str]:
 
     logger.info("Loading registry result links...")
     registry_result_links = set()
-    with gzip.open(pkl_path, "rb") as f:
+    with gzip.open(trial_pkl_path, "rb") as f:
         trials = pickle.load(f)
     for trial in trials:
         if trial.references:
@@ -59,7 +59,7 @@ def get_intersection_pmids(limit: int = None) -> list[str]:
 
     logger.info("Loading PubMed scan links...")
     pubmed_pmids = set()
-    with open(csv_path, "r") as f:
+    with open(pubmed_nct_links_path, "r") as f:
         reader = csv.reader(f)
         next(reader)
         for row in reader:

--- a/src/trialsynth/base/extract/orchestrate.py
+++ b/src/trialsynth/base/extract/orchestrate.py
@@ -32,7 +32,7 @@ from indra.literature.pubmed_client import get_pmid_to_package_url_mapping, get_
 
 from trialsynth.base.extract.extract import process_pmid
 
-output_dir  = pystow.module("indra", "cogex", "clinical_trial_results", "raw")
+output_dir  = pystow.module("trialsynth", "results", "raw")
 txt_archive = pystow.module("trialsynth", "content", "txt")
 pdf_archive = pystow.module("trialsynth", "content", "pdfs")
 temp_work   = pystow.module("trialsynth", "content", "temp")
@@ -168,7 +168,7 @@ def run_extraction(pmids: list[str]):
         total_out = sum(r["output_tokens"] for r in stats if r["status"] == "completed")
         logger.info(f"Avg output tokens/paper: {total_out // statuses['completed']}")
 
-    csv_path = pystow.module("indra", "cogex", "clinical_trial_results").base / "extraction_stats.csv"
+    csv_path = pystow.join("trialsynth", "results", name="extraction_stats.csv")
     with open(csv_path, "w", newline="") as f:
         writer = csv.DictWriter(f, fieldnames=["pmid", "status", "input_tokens", "output_tokens"])
         writer.writeheader()
@@ -182,8 +182,7 @@ def main():
                         help="Max PMIDs to process (default: 1000)")
     args = parser.parse_args()
 
-    pmids_path = pystow.join("indra", "cogex", "clinical_trial_results",
-                             name="intersection_pmids.txt")
+    pmids_path = pystow.join("trialsynth", "results", name="intersection_pmids.txt")
 
     if pmids_path.exists():
         with open(pmids_path, "r") as f:

--- a/src/trialsynth/base/extract/pmc_s3.py
+++ b/src/trialsynth/base/extract/pmc_s3.py
@@ -1,0 +1,53 @@
+"""PMC Cloud S3 text fetching helpers."""
+
+import re
+import xml.etree.ElementTree as ET
+from functools import lru_cache
+
+import requests
+
+PMC_S3_BASE = "https://pmc-oa-opendata.s3.amazonaws.com"
+_S3_NS = {"s3": "http://s3.amazonaws.com/doc/2006-03-01/"}
+
+
+@lru_cache(maxsize=10000)
+def get_s3_versions(pmcid: str) -> tuple[int, ...]:
+    """Return sorted tuple of available version numbers for a PMC article on S3."""
+    res = requests.get(PMC_S3_BASE, params={"prefix": f"{pmcid}.", "delimiter": "/"})
+    res.raise_for_status()
+    tree = ET.fromstring(res.content)
+    versions = []
+    for el in tree.findall("s3:CommonPrefixes/s3:Prefix", _S3_NS):
+        m = re.match(rf"{re.escape(pmcid)}\.(\d+)/", el.text or "")
+        if m:
+            versions.append(int(m.group(1)))
+    return tuple(sorted(versions))
+
+
+def get_latest_s3_version(pmcid: str) -> int | None:
+    """Return the latest available version number, or None if not on S3."""
+    versions = get_s3_versions(pmcid)
+    return max(versions) if versions else None
+
+
+def _get_s3_artifact(
+    pmcid: str, ext: str, version: int | None = None
+) -> requests.Response | None:
+    """Fetch a file artifact for a PMC article from the public S3 bucket."""
+    if version is None:
+        version = get_latest_s3_version(pmcid)
+        if version is None:
+            return None
+    url = f"{PMC_S3_BASE}/{pmcid}.{version}/{pmcid}.{version}.{ext}"
+    res = requests.get(url, timeout=60)
+    res.raise_for_status()
+    return res
+
+
+def get_text_s3(pmcid: str, version: int | None = None) -> str | None:
+    """Return plain text for a PMC article from S3, or None if unavailable."""
+    try:
+        res = _get_s3_artifact(pmcid, "txt", version=version)
+        return res.text if res is not None else None
+    except Exception:
+        return None

--- a/src/trialsynth/base/ground.py
+++ b/src/trialsynth/base/ground.py
@@ -156,6 +156,7 @@ class Grounder:
         self, entity: BioEntity, *, db_ns, db_id: str, norm_text: str
     ) -> BioEntity:
         grounded_entity = copy.deepcopy(entity)
+        grounded_entity.grounding_source = "gilda"
         grounded_entity.ns = db_ns
         grounded_entity.ns_id = db_id
         grounded_entity.grounded_term = norm_text
@@ -203,6 +204,7 @@ class Grounder:
                     yield from self._yield_entity(entity, matches[0])
         # If the entity already has a namespace and ID, we assume it's already grounded
         elif entity.ns and entity.ns_id:
+            assert entity.grounding_source, "Grounding source must be provided if entity has namespace and ID"
             yield entity
         # Otherwise, we ground the entity using Gilda
         else:

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -424,9 +424,16 @@ class Edge:
         The type of relation.
     """
 
-    def __init__(self, trial: Trial, entity: BioEntity,source: str):
+    def __init__(
+        self,
+        trial: Trial,
+        entity: BioEntity,
+        source: str,
+        grounding_source: Literal["gilda", "mesh"],
+    ):
         self.trial = trial
         self.entity = entity
         self.source = source
 
-        self.rel_type = f'has_{type(entity).__name__.lower()}'
+        self.rel_type = f"has_{type(entity).__name__.lower()}"
+        self.grounding_source = Literal["gilda", "mesh"] = grounding_source

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, Literal
 
 import indra.statements.agent as agent
 from bioregistry import curie_to_str
@@ -204,10 +204,11 @@ class BioEntity(Node):
         labels: list[str],
         origin: str,
         source: str,
+        grounding_source: Optional[Literal["gilda", "mesh"]] = None,
         description: Optional[str] = None,
         ns: Optional[str] = None,
         id: Optional[str] = None,
-        grounded_term: Optional[str] = None
+        grounded_term: Optional[str] = None,
     ):
         super().__init__(ns=ns, ns_id=id, source=source)
         self.labels = labels
@@ -215,6 +216,7 @@ class BioEntity(Node):
         self.description: str = description
         self.origin: str = origin
         self.grounded_term: str = grounded_term
+        self.grounding_source: str = grounding_source
 
 
 class Condition(BioEntity):
@@ -243,6 +245,7 @@ class Condition(BioEntity):
         text: str,
         origin: str,
         source: str,
+        grounding_source: Optional[Literal["gilda", "mesh"]] = None,
         description: Optional[str] = None,
         labels: Optional[list[str]] = None,
         ns: Optional[str] = None,
@@ -253,6 +256,7 @@ class Condition(BioEntity):
             labels=['condition'],
             origin=origin,
             source=source,
+            grounding_source=grounding_source,
             ns=ns,
             id=id,
             description=description,
@@ -302,6 +306,7 @@ class Intervention(BioEntity):
         text: str,
         origin: str,
         source: str,
+        grounding_source: Optional[Literal["gilda", "mesh"]] = None,
         description: Optional[str] = None,
         labels: Optional[list[str]] = None,
         ns: Optional[str] = None,
@@ -312,6 +317,7 @@ class Intervention(BioEntity):
             description=description,
             labels=['intervention'],
             origin=origin,
+            grounding_source=grounding_source,
             source=source,
             ns=ns,
             id=id

--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -436,4 +436,4 @@ class Edge:
         self.source = source
 
         self.rel_type = f"has_{type(entity).__name__.lower()}"
-        self.grounding_source = Literal["gilda", "mesh"] = grounding_source
+        self.grounding_source: Literal["gilda", "mesh"] = grounding_source

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -183,7 +183,6 @@ class Processor:
         self.intervention_grounder.ground("stuff")
         logger.info("Done.")
 
-
         for ent_type, entities, grounder in zip(
             self.entities.keys(),
             self.entities.values(),
@@ -205,7 +204,6 @@ class Processor:
 
                     trial.entities.extend(entities)
 
-
     def create_edges(self):
         """Creates edges connecting trials to related bioentities."""
 
@@ -215,7 +213,17 @@ class Processor:
             unit="trial",
             unit_scale=True,
         ):
-            self.edges.extend([Edge(trial, entity, self.config.registry) for entity in trial.entities])
+            self.edges.extend(
+                [
+                    Edge(
+                        trial,
+                        entity,
+                        self.config.registry,
+                        grounding_source=entity.grounding_source,
+                    )
+                    for entity in trial.entities
+                ]
+            )
 
     def save_trial_data(
         self, path: Path, sample_path: Optional[Path] = None
@@ -327,13 +335,14 @@ class Processor:
         edges = [self.transformer.flatten_edge(edge) for edge in self.edges]
 
         store.save_data_as_flatfile(
-            list(set(edges)),
+            list(set(edges)),  # Remove duplicate edges
             path=path,
             headers=[
                 "from:CURIE",
                 "to:CURIE",
                 "rel_type:string",
                 "source_registry:string",
+                "grounding_source:string",
             ],
             sample_path=sample_path,
             num_samples=self.config.num_sample_entries,

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -162,7 +162,7 @@ class Transformer:
         )
 
     @staticmethod
-    def flatten_edge(edge: Edge) -> Tuple[str, str, str, str]:
+    def flatten_edge(edge: Edge) -> Tuple[str, str, str, str, str]:
         """Flattens an Edge into a tuple of strings.
 
         Parameters
@@ -172,12 +172,14 @@ class Transformer:
 
         Returns
         -------
-        Tuple[str, str, str, str]
-            A tuple of the flattened Edge. In order of trial_curie, bio_ent_curie, rel_type, rel_type_curie, source.
+        Tuple[str, str, str, str, str]
+            A tuple of the flattened Edge. In order of trial_curie,
+            bio_ent_curie, rel_type, rel_type_curie, source, grounding_source.
         """
         return (
             edge.trial.curie,
             edge.entity.curie,
             edge.rel_type,
             edge.source,
+            edge.grounding_source
         )

--- a/src/trialsynth/ctgov/fetch.py
+++ b/src/trialsynth/ctgov/fetch.py
@@ -231,6 +231,7 @@ class CTFetcher(Fetcher):
                         text=mesh.term,
                         origin=trial.curie,
                         source=self.config.registry,
+                        grounding_source="mesh"
                     )
                     for mesh in condition_meshes
                 ]
@@ -264,6 +265,7 @@ class CTFetcher(Fetcher):
                         text=mesh.term,
                         origin=trial.curie,
                         source=self.config.registry,
+                        grounding_source="mesh"
                     )
                     for mesh in intervention_meshes
                 ]


### PR DESCRIPTION
- Replaces the PMC FTP download pipeline with direct PMC S3 text fetching. 
   - The legacy FTP endpoint was retired in April 2026. 
   - New approach resolves PMCID via id_lookup, fetches plain text directly from the public PMC S3 bucket, and falls back to abstract if no PMCID exists. 
- Adds pmc_s3.py with 4 S3 helper functions.