### PR TITLE
Extend trial-publication relations

### DIFF
--- a/src/trialsynth/base/models.py
+++ b/src/trialsynth/base/models.py
@@ -458,7 +458,11 @@ class PublicationEdge:
         self,
         trial: str,
         publication: str,
+        source: str,
+        ref_type: Optional[str] = None,
     ):
         self.trial = trial
         self.publication = publication
         self.rel_type = "has_publication"
+        self.source = source
+        self.ref_type = ref_type

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -260,17 +260,31 @@ class Processor:
                     )
                 )
 
-            # Create trial - publication edges; but only the ones that are
-            # present both from pubmed and clinicaltrials.gov. Data is
-            # downloaded in the CTFetcher.get_api_data method
+            # Create trial - publication edges from trial data
             for pmid, ref_type in trial.references:
-                if ref_type.lower() == "result" and (pmid, trial.ns_id) in pubmed_trial_links:
-                    self.trial_publication_edges.append(
-                        PublicationEdge(
-                            trial=trial.curie,
-                            publication=pmid,
-                        )
+                self.trial_publication_edges.append(
+                    PublicationEdge(
+                        trial=trial.curie,
+                        publication=pmid,
+                        source="clinicaltrials.gov",
+                        ref_type=ref_type,
                     )
+                )
+
+        # Create trial - publication edges from PubMed XML data
+        for pmid, nct_id in tqdm(
+            pubmed_trial_links,
+            desc="Processing PubMed data",
+            unit="publication",
+            unit_scale=True,
+        ):
+            self.trial_publication_edges.append(
+                PublicationEdge(
+                    trial=nct_id,
+                    publication=pmid,
+                    source="pubmed",
+                )
+            )
 
     def save_trial_data(
         self, path: Path, sample_path: Optional[Path] = None
@@ -403,8 +417,8 @@ class Processor:
         path :
             The path to save the processed trial publication edges
         sample_path :
-            If provided, save the processed trial publication edges
-            (default: None).
+            If provided, save a sample of the processed trial publication edges
+            to this path. Defaults to None.
         """
         edges = [
             self.transformer.flatten_trial_publication_edge(edge)
@@ -419,6 +433,8 @@ class Processor:
                 "trial_id",
                 "pmid",
                 "rel_type",
+                "source",
+                "ref_type",
             ],
             sample_path=sample_path,
             num_samples=self.config.num_sample_entries,

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -270,7 +270,7 @@ class Processor:
                     PublicationEdge(
                         trial=trial.curie,
                         publication=pmid,
-                        source="clinicaltrials.gov",
+                        source="ctgov",
                         ref_type=ref_type,
                     )
                 )
@@ -282,7 +282,7 @@ class Processor:
         # Create trial - publication edges from PubMed XML data
         for pmid, nct_id in tqdm(
             pubmed_trial_links,
-            desc="Processing PubMed data",
+            desc="Generating trial-PubMed edges from PubMed",
             unit="publication",
             unit_scale=True,
         ):
@@ -428,7 +428,7 @@ class Processor:
             The path to save the processed trial publication edges
         sample_path :
             If provided, save a sample of the processed trial publication edges
-            to this path. Defaults to None.
+            to this path. Default: None.
         """
         edges = [
             self.transformer.flatten_trial_publication_edge(edge)

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -290,11 +290,11 @@ class Processor:
             for nct_id in nct_ids:
                 self.trial_publication_edges.append(
                     PublicationEdge(
-                        trial=nct_id,
-                            publication=pmid,
-                            source="pubmed",
-                        )
+                        trial=f"clinicaltrials:{nct_id}",
+                        publication=pmid,
+                        source="pubmed",
                     )
+                )
 
     def save_trial_data(
         self, path: Path, sample_path: Optional[Path] = None

--- a/src/trialsynth/base/process.py
+++ b/src/trialsynth/base/process.py
@@ -1,3 +1,4 @@
+import re
 import csv
 import gzip
 import logging
@@ -18,6 +19,9 @@ from .validate import Validator
 from ..base.extract.build_pubmed_nct_links import PMID_NCT_LINKS
 
 logger = logging.getLogger(__name__)
+
+
+NCT_EXTRACT_RE = re.compile(r"NCT\s*(\d{8})", re.IGNORECASE)
 
 
 def run_processor(
@@ -271,6 +275,10 @@ class Processor:
                     )
                 )
 
+        def _extract_nct_ids(raw: str) -> list[str]:
+            # Return canonical NCT######## IDs found in a raw accession string
+            return [f"NCT{digits}" for digits in NCT_EXTRACT_RE.findall(raw)]
+
         # Create trial - publication edges from PubMed XML data
         for pmid, nct_id in tqdm(
             pubmed_trial_links,
@@ -278,13 +286,15 @@ class Processor:
             unit="publication",
             unit_scale=True,
         ):
-            self.trial_publication_edges.append(
-                PublicationEdge(
-                    trial=nct_id,
-                    publication=pmid,
-                    source="pubmed",
-                )
-            )
+            nct_ids = _extract_nct_ids(nct_id)
+            for nct_id in nct_ids:
+                self.trial_publication_edges.append(
+                    PublicationEdge(
+                        trial=nct_id,
+                            publication=pmid,
+                            source="pubmed",
+                        )
+                    )
 
     def save_trial_data(
         self, path: Path, sample_path: Optional[Path] = None

--- a/src/trialsynth/base/transform.py
+++ b/src/trialsynth/base/transform.py
@@ -185,7 +185,9 @@ class Transformer:
         )
 
     @staticmethod
-    def flatten_trial_publication_edge(trial_pub_edge: PublicationEdge) -> Tuple[str, str, str]:
+    def flatten_trial_publication_edge(
+        trial_pub_edge: PublicationEdge
+    ) -> Tuple[str, str, str, str, str]:
         """Flattens a PublicationEdge into a tuple of strings.
 
         Parameters
@@ -197,10 +199,12 @@ class Transformer:
         -------
         :
             A tuple of the flattened PublicationEdge. In order of trial_curie,
-            pmid, rel_type
+            pmid, rel_type, source, ref_type
         """
         return (
             trial_pub_edge.trial,
             trial_pub_edge.publication,
             trial_pub_edge.rel_type,
+            trial_pub_edge.source,
+            trial_pub_edge.ref_type or "",
         )


### PR DESCRIPTION
This PR extends the trial-publication edges to include all relations from both the PubMed XML dump and clinicaltrials.gov's references, and not restrict the relations to any predetermined filtering. Instead, this update adds a source tag to relations (`pubmed` vs `ctgov`) and adds a reference type tag (`result`, `background`, and `dervied`) for the PMIDs coming from clinicaltrials.gov.